### PR TITLE
Add Function for Setting GitHub Actions Outputs

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,7 @@
-import { getInput } from "./index.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getInput, setOutput } from "./index.js";
 
 describe("retrieve GitHub Actions inputs", () => {
   it("should retrieve a GitHub Actions input", () => {
@@ -8,5 +11,31 @@ describe("retrieve GitHub Actions inputs", () => {
 
   it("should retrieve an empty GitHub Actions input", () => {
     expect(getInput("some-empty-input")).toBe("");
+  });
+});
+
+describe("set GitHub Actions outputs", () => {
+  let tempFile: string;
+  beforeAll(() => {
+    tempFile = path.join(os.tmpdir(), "output");
+    process.env["GITHUB_OUTPUT"] = tempFile;
+    if (fs.existsSync(tempFile)) {
+      fs.rmSync(tempFile);
+    }
+  });
+
+  it("should set GitHub Actions outputs", () => {
+    setOutput("some-output", "some value");
+    setOutput("some-other-output", "some other value");
+
+    expect(fs.readFileSync(tempFile, { encoding: "utf-8" })).toBe(
+      `some-output=some value${os.EOL}some-other-output=some other value${os.EOL}`,
+    );
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(tempFile)) {
+      fs.rmSync(tempFile);
+    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+
 /**
  * Retrieves the value of a GitHub Actions input.
  *
@@ -7,4 +10,17 @@
 export function getInput(name: string): string {
   const value = process.env[`INPUT_${name.toUpperCase()}`] || "";
   return value.trim();
+}
+
+/**
+ * Sets the value of a GitHub Actions output.
+ *
+ * @param name - The name of the GitHub Actions output.
+ * @param value - The value of the GitHub Actions output
+ */
+export function setOutput(name: string, value: string): void {
+  fs.appendFileSync(
+    process.env["GITHUB_OUTPUT"] as string,
+    `${name}=${value}${os.EOL}`,
+  );
 }


### PR DESCRIPTION
This pull request resolves #7 by adding a new `setOutput` function along with its test.