### PR TITLE
Rename Error Function to Log Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ setOutput("output-name", "some value");
 
 ### Logging Errors
 
-Errors can be logged using the `error` function, which can log errors of any type. This is especially useful for logging caught errors:
+Errors can be logged using the `logError` function, which can log errors of any type. This is especially useful for logging caught errors:
 
 ```ts
 try {
   // Do something
 } catch (err) {
-  error(err);
+  logError(err);
 }
 ```
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,7 +2,7 @@ import { jest } from "@jest/globals";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { error, getInput, setOutput } from "./index.js";
+import { getInput, logError, setOutput } from "./index.js";
 
 describe("retrieve GitHub Actions inputs", () => {
   it("should retrieve a GitHub Actions input", () => {
@@ -41,7 +41,7 @@ describe("set GitHub Actions outputs", () => {
   });
 });
 
-describe("log errors on GitHub Actions", () => {
+describe("log errors in GitHub Actions", () => {
   let stdoutData: string;
   beforeAll(() => {
     jest
@@ -52,15 +52,15 @@ describe("log errors on GitHub Actions", () => {
       });
   });
 
-  it("should log an error message on GitHub Actions", () => {
+  it("should log an error message in GitHub Actions", () => {
     stdoutData = "";
-    error("some error message");
+    logError("some error message");
     expect(stdoutData).toBe(`::error::some error message${os.EOL}`);
   });
 
-  it("should log an error object on GitHub Actions", () => {
+  it("should log an error object in GitHub Actions", () => {
     stdoutData = "";
-    error(new Error("some error object"));
+    logError(new Error("some error object"));
     expect(stdoutData).toBe(`::error::some error object${os.EOL}`);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,11 +26,11 @@ export function setOutput(name: string, value: string): void {
 }
 
 /**
- * Logs an error message on GitHub Actions.
+ * Logs an error message in GitHub Actions.
  *
  * @param err - The error, which can be of any type.
  */
-export function error(err: unknown): void {
+export function logError(err: unknown): void {
   const message = err instanceof Error ? err.message : String(err);
   process.stdout.write(`::error::${message}${os.EOL}`);
 }


### PR DESCRIPTION
This pull request resolves #14 by simply renaming the `error` function to `logError`.