### PR TITLE
Add Functions for Groupping Log in GitHub Actions

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,7 +2,14 @@ import { jest } from "@jest/globals";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { getInput, logError, logInfo, setOutput } from "./index.js";
+import {
+  beginLogGroup,
+  endLogGroup,
+  getInput,
+  logError,
+  logInfo,
+  setOutput,
+} from "./index.js";
 
 let stdoutData: string;
 beforeAll(() => {
@@ -70,5 +77,19 @@ describe("log errors in GitHub Actions", () => {
     stdoutData = "";
     logError(new Error("some error object"));
     expect(stdoutData).toBe(`::error::some error object${os.EOL}`);
+  });
+});
+
+describe("begin and end log groups in GitHub Actions", () => {
+  it("should begin a log group in GitHub Actions", () => {
+    stdoutData = "";
+    beginLogGroup("some log group");
+    expect(stdoutData).toBe(`::group::some log group${os.EOL}`);
+  });
+
+  it("should end the current log group in GitHub Actions", () => {
+    stdoutData = "";
+    endLogGroup();
+    expect(stdoutData).toBe(`::endgroup::${os.EOL}`);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,3 +43,19 @@ export function logError(err: unknown): void {
   const message = err instanceof Error ? err.message : String(err);
   process.stdout.write(`::error::${message}${os.EOL}`);
 }
+
+/**
+ * Begins a log group in GitHub Actions.
+ *
+ * @param name - The name of the log group.
+ */
+export function beginLogGroup(name: string): void {
+  process.stdout.write(`::group::${name}${os.EOL}`);
+}
+
+/**
+ * Ends the current log group in GitHub Actions.
+ */
+export function endLogGroup(): void {
+  process.stdout.write(`::endgroup::${os.EOL}`);
+}


### PR DESCRIPTION
This pull request resolves #20 by adding new `beginLogGroup` and `endLogGroup` functions along with its test.