### PR TITLE
Add Function for Logging Warning in GitHub Actions

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   getInput,
   logError,
   logInfo,
+  logWarning,
   setOutput,
 } from "./index.js";
 
@@ -63,6 +64,14 @@ describe("log information in GitHub Actions", () => {
     stdoutData = "";
     logInfo("some information message");
     expect(stdoutData).toBe(`some information message${os.EOL}`);
+  });
+});
+
+describe("log warnings in GitHub Actions", () => {
+  it("should log a warning message in GitHub Actions", () => {
+    stdoutData = "";
+    logWarning("some warning message");
+    expect(stdoutData).toBe(`::warning::some warning message${os.EOL}`);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,15 @@ export function logInfo(message: string): void {
 }
 
 /**
+ * Logs a warning message in GitHub Actions.
+ *
+ * @param message - The warning message to log.
+ */
+export function logWarning(message: string): void {
+  process.stdout.write(`::warning::${message}${os.EOL}`);
+}
+
+/**
  * Logs an error message in GitHub Actions.
  *
  * @param err - The error, which can be of any type.


### PR DESCRIPTION
This pull request resolves #22 by adding a new `logWarning` function along with its tests.