### PR TITLE
Add Function for Setting Environment Variables in GitHub Actions

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,6 +9,7 @@ import {
   logError,
   logInfo,
   logWarning,
+  setEnv,
   setOutput,
 } from "./index.js";
 
@@ -49,6 +50,32 @@ describe("set GitHub Actions outputs", () => {
 
     expect(fs.readFileSync(tempFile, { encoding: "utf-8" })).toBe(
       `some-output=some value${os.EOL}some-other-output=some other value${os.EOL}`,
+    );
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(tempFile)) {
+      fs.rmSync(tempFile);
+    }
+  });
+});
+
+describe("set environment variables in GitHub Actions", () => {
+  let tempFile: string;
+  beforeAll(() => {
+    tempFile = path.join(os.tmpdir(), "env");
+    process.env["GITHUB_ENV"] = tempFile;
+    if (fs.existsSync(tempFile)) {
+      fs.rmSync(tempFile);
+    }
+  });
+
+  it("should set environment variables in GitHub Actions", () => {
+    setEnv("some-env", "some value");
+    setEnv("some-other-env", "some other value");
+
+    expect(fs.readFileSync(tempFile, { encoding: "utf-8" })).toBe(
+      `some-env=some value${os.EOL}some-other-env=some other value${os.EOL}`,
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,19 @@ export function setOutput(name: string, value: string): void {
 }
 
 /**
+ * Sets the value of an environment variable in GitHub Actions.
+ *
+ * @param name - The name of the environment variable.
+ * @param value - The value of the environment variable.
+ */
+export function setEnv(name: string, value: string): void {
+  fs.appendFileSync(
+    process.env["GITHUB_ENV"] as string,
+    `${name}=${value}${os.EOL}`,
+  );
+}
+
+/**
  * Logs an information message in GitHub Actions.
  *
  * @param message - The information message to log.


### PR DESCRIPTION
This pull request resolves #27 by adding a new `setEnv` function along with its tests.