### PR TITLE
Modify `setEnv` Function to Also Set Variables in Current Environment

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -72,11 +72,14 @@ describe("set environment variables in GitHub Actions", () => {
   });
 
   it("should set environment variables in GitHub Actions", () => {
-    setEnv("some-env", "some value");
-    setEnv("some-other-env", "some other value");
+    setEnv("SOME_ENV", "some value");
+    setEnv("SOME_OTHER_ENV", "some other value");
+
+    expect(process.env.SOME_ENV).toBe("some value");
+    expect(process.env.SOME_OTHER_ENV).toBe("some other value");
 
     expect(fs.readFileSync(tempFile, { encoding: "utf-8" })).toBe(
-      `some-env=some value${os.EOL}some-other-env=some other value${os.EOL}`,
+      `SOME_ENV=some value${os.EOL}SOME_OTHER_ENV=some other value${os.EOL}`,
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export function setOutput(name: string, value: string): void {
  * @param value - The value of the environment variable.
  */
 export function setEnv(name: string, value: string): void {
+  process.env[name] = value;
   fs.appendFileSync(
     process.env["GITHUB_ENV"] as string,
     `${name}=${value}${os.EOL}`,


### PR DESCRIPTION
This pull request resolves #31 by modifying the `setEnv` function to also set the environment variables in the current environment in addition to exporting them to other steps.