### PR TITLE
Add Function to Log Commands in GitHub Actions

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   beginLogGroup,
   endLogGroup,
   getInput,
+  logCommand,
   logError,
   logInfo,
   logWarning,
@@ -149,6 +150,14 @@ describe("log errors in GitHub Actions", () => {
     stdoutData = "";
     logError(new Error("some error object"));
     expect(stdoutData).toBe(`::error::some error object${os.EOL}`);
+  });
+});
+
+describe("log commands in GitHub Actions", () => {
+  it("should log a command in GitHub Actions", () => {
+    stdoutData = "";
+    logCommand("cmd", ["arg0", "arg1", "arg2"]);
+    expect(stdoutData).toBe(`[command]cmd arg0 arg1 arg2${os.EOL}`);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,17 @@ export function logError(err: unknown): void {
 }
 
 /**
+ * Logs a command along with its arguments in GitHub Actions.
+ *
+ * @param command - The command to log.
+ * @param args - The arguments of the command.
+ */
+export function logCommand(command: string, args: string[]): void {
+  const message = [command, ...args].join(" ");
+  process.stdout.write(`[command]${message}${os.EOL}`);
+}
+
+/**
  * Begins a log group in GitHub Actions.
  *
  * @param name - The name of the log group.


### PR DESCRIPTION
This pull request resolves #33 by adding a new `logCommand` function along with its tests.