### PR TITLE
Specify Package Artifact Name in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Upload Package
         uses: actions/upload-artifact@v4.3.6
         with:
+          name: package
           path: package.tgz
 
   build-docs:


### PR DESCRIPTION
This pull request simply specifies the name of a package artifact that is uploaded in the `build` workflow.