### PR TITLE
Unspecify Yarn Version in Workflow 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
 
       - name: Build Package
         run: yarn pack
@@ -45,8 +43,6 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
 
       - name: Build Documentation
         run: yarn docs

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
 
       - name: Check Formatting
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
 
       - name: Build Documentation
         run: yarn docs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
 
       - name: Test Package
         run: yarn test


### PR DESCRIPTION
This pull request resolves #55 by not specifying the Yarn version when setting up Yarn in GitHub workflows.