### PR TITLE
Mark Arrays as Readonly in Function Parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ export function logError(err: unknown): void {
  * @param command - The command to log.
  * @param args - The arguments of the command.
  */
-export function logCommand(command: string, args: string[]): void {
+export function logCommand(command: string, args: readonly string[]): void {
   const message = [command, ...args].join(" ");
   process.stdout.write(`[command]${message}${os.EOL}`);
 }


### PR DESCRIPTION
This pull request resolves #66 by marking all arrays in function parameters as `readonly`, preventing any modification to the arrays within the functions.