### PR TITLE
Fix ESLint Configuration Does Not Ignore Docs Directory

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,6 @@ export default [
   ...tseslint.configs.recommended,
   ...tseslint.configs.stylistic,
   {
-    ignores: [".*", "dist"],
+    ignores: [".*", "dist", "docs"],
   },
 ];


### PR DESCRIPTION
This pull request resolves #68 by updating the `eslint.config.js` file to ignore the `docs` directory from being checked by ESLint.