### PR TITLE
Modify Certain Functions to Be Asynchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GitHub Actions inputs can be retrieved using the `getInput` function, which retu
 ```ts
 const input = getInput("input-name");
 
-setOutput("output-name", "some value");
+await setOutput("output-name", "some value");
 ```
 
 ### Setting Environment Variables

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ await setOutput("output-name", "some value");
 Environment variables in GitHub Actions can be set using the `setEnv` function, which sets the environment variables in the current step and exports them to the next steps:
 
 ```ts
-setEnv("SOME_ENV", "some value");
+await setEnv("SOME_ENV", "some value");
 ```
 
 ### Adding System Paths

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ await setEnv("SOME_ENV", "some value");
 System paths in the GitHub Actions environment can be added using the `addPath` function, which prepends the given path to the system path. This function is useful if an action is adding a new executable located in a custom path:
 
 ```ts
-addPath("path/to/some/executable");
+await addPath("path/to/some/executable");
 ```
 
 ### Logging Messages

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,4 +8,10 @@ export default [
   {
     ignores: [".*", "dist", "docs"],
   },
+  {
+    files: ["**/*.test.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -17,10 +18,11 @@ export function getInput(name: string): string {
  * Sets the value of a GitHub Actions output.
  *
  * @param name - The name of the GitHub Actions output.
- * @param value - The value of the GitHub Actions output
+ * @param value - The value to set for the GitHub Actions output.
+ * @returns A promise that resolves when the value is successfully set.
  */
-export function setOutput(name: string, value: string): void {
-  fs.appendFileSync(
+export async function setOutput(name: string, value: string): Promise<void> {
+  await fsPromises.appendFile(
     process.env["GITHUB_OUTPUT"] as string,
     `${name}=${value}${os.EOL}`,
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -47,11 +46,12 @@ export async function setEnv(name: string, value: string): Promise<void> {
 /**
  * Adds a system path to the environment in GitHub Actions.
  *
- * @param sysPath - The system path to add.
+ * @param sysPath - The system path to add to the environment.
+ * @returns A promise that resolves when the system path is successfully added.
  */
-export function addPath(sysPath: string): void {
+export async function addPath(sysPath: string): Promise<void> {
   process.env["PATH"] = `${sysPath}${path.delimiter}${process.env["PATH"]}`;
-  fs.appendFileSync(
+  await fsPromises.appendFile(
     process.env["GITHUB_PATH"] as string,
     `${sysPath}${os.EOL}`,
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,13 @@ export async function setOutput(name: string, value: string): Promise<void> {
  * Sets the value of an environment variable in GitHub Actions.
  *
  * @param name - The name of the environment variable.
- * @param value - The value of the environment variable.
+ * @param value - The value to set for the environment variable.
+ * @returns A promise that resolves when the environment variable is
+ *          successfully set.
  */
-export function setEnv(name: string, value: string): void {
+export async function setEnv(name: string, value: string): Promise<void> {
   process.env[name] = value;
-  fs.appendFileSync(
+  await fsPromises.appendFile(
     process.env["GITHUB_ENV"] as string,
     `${name}=${value}${os.EOL}`,
   );


### PR DESCRIPTION
This pull request resolves #77 by modifying the `setOutput`, `setEnv`, and `addPath` functions to be asynchronous by utilizing `fsPromises.appendFile` instead of `fs.appendFileSync`. This change prevents calls to these functions from blocking the main thread.