### PR TITLE
Add Synchronous Versions of Asynchronous Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ setOutputSync("other-output-name", "some other value");
 
 ### Setting Environment Variables
 
-Environment variables in GitHub Actions can be set using the `setEnv` function, which sets the environment variables in the current step and exports them to the next steps:
+Environment variables in GitHub Actions can be set using the `setEnv` or `setEnvSync` functions, which sets the environment variables in the current step and exports them to the next steps:
 
 ```ts
 await setEnv("SOME_ENV", "some value");
+setEnvSync("SOME_OTHER_ENV", "some other value");
 ```
 
 ### Adding System Paths

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ A minimalistic utility package for developing [GitHub Actions](https://github.co
 
 ### Getting Inputs and Setting Outputs
 
-GitHub Actions inputs can be retrieved using the `getInput` function, which returns a trimmed string or an empty string if the input is not specified. GitHub Actions outputs can be set using the `setOutput` function:
+GitHub Actions inputs can be retrieved using the `getInput` function, which returns a trimmed string or an empty string if the input is not specified. GitHub Actions outputs can be set using the `setOutput` or `setOutputSync` functions:
 
 ```ts
 const input = getInput("input-name");
 
 await setOutput("output-name", "some value");
+setOutputSync("other-output-name", "some other value");
 ```
 
 ### Setting Environment Variables

--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ setEnvSync("SOME_OTHER_ENV", "some other value");
 
 ### Adding System Paths
 
-System paths in the GitHub Actions environment can be added using the `addPath` function, which prepends the given path to the system path. This function is useful if an action is adding a new executable located in a custom path:
+System paths in the GitHub Actions environment can be added using the `addPath` or `addPathSync` functions, which prepends the given path to the system path. These functions are useful if an action is adding a new executable located in a custom path:
 
 ```ts
 await addPath("path/to/some/executable");
+addPathSync("path/to/some/executable");
 ```
 
 ### Logging Messages

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -14,6 +14,7 @@ import {
   logWarning,
   setEnv,
   setOutput,
+  setOutputSync,
 } from "./index.js";
 
 let stdoutData: string;
@@ -39,7 +40,7 @@ describe("retrieve GitHub Actions inputs", () => {
 
 describe("set GitHub Actions outputs", () => {
   let tempFile: string;
-  beforeAll(async () => {
+  beforeEach(async () => {
     tempFile = path.join(os.tmpdir(), "output");
     process.env["GITHUB_OUTPUT"] = tempFile;
     try {
@@ -66,7 +67,17 @@ describe("set GitHub Actions outputs", () => {
     ]);
   });
 
-  afterAll(async () => {
+  it("should set GitHub Actions outputs synchronously", async () => {
+    setOutputSync("some-output", "some value");
+    setOutputSync("some-other-output", "some other value");
+
+    const content = await fsPromises.readFile(tempFile, { encoding: "utf-8" });
+    expect(content).toBe(
+      `some-output=some value${os.EOL}some-other-output=some other value${os.EOL}`,
+    );
+  });
+
+  afterEach(async () => {
     try {
       await fsPromises.rm(tempFile);
     } catch (err) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   logInfo,
   logWarning,
   setEnv,
+  setEnvSync,
   setOutput,
   setOutputSync,
 } from "./index.js";
@@ -88,7 +89,7 @@ describe("set GitHub Actions outputs", () => {
 
 describe("set environment variables in GitHub Actions", () => {
   let tempFile: string;
-  beforeAll(async () => {
+  beforeEach(async () => {
     tempFile = path.join(os.tmpdir(), "env");
     process.env["GITHUB_ENV"] = tempFile;
     try {
@@ -118,7 +119,20 @@ describe("set environment variables in GitHub Actions", () => {
     ]);
   });
 
-  afterAll(async () => {
+  it("should set environment variables in GitHub Actions synchronously", async () => {
+    setEnvSync("SOME_ENV", "some value");
+    setEnvSync("SOME_OTHER_ENV", "some other value");
+
+    expect(process.env.SOME_ENV).toBe("some value");
+    expect(process.env.SOME_OTHER_ENV).toBe("some other value");
+
+    const content = await fsPromises.readFile(tempFile, { encoding: "utf-8" });
+    expect(content).toBe(
+      `SOME_ENV=some value${os.EOL}SOME_OTHER_ENV=some other value${os.EOL}`,
+    );
+  });
+
+  afterEach(async () => {
     try {
       await fsPromises.rm(tempFile);
     } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,20 @@ export async function setEnv(name: string, value: string): Promise<void> {
 }
 
 /**
+ * Sets the value of an environment variable in GitHub Actions synchronously.
+ *
+ * @param name - The name of the environment variable.
+ * @param value - The value to set for the environment variable.
+ */
+export function setEnvSync(name: string, value: string): void {
+  process.env[name] = value;
+  fs.appendFileSync(
+    process.env["GITHUB_ENV"] as string,
+    `${name}=${value}${os.EOL}`,
+  );
+}
+
+/**
  * Adds a system path to the environment in GitHub Actions.
  *
  * @param sysPath - The system path to add to the environment.

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,19 @@ export async function addPath(sysPath: string): Promise<void> {
 }
 
 /**
+ * Adds a system path to the environment in GitHub Actions synchronously.
+ *
+ * @param sysPath - The system path to add to the environment.
+ */
+export function addPathSync(sysPath: string): void {
+  process.env["PATH"] = `${sysPath}${path.delimiter}${process.env["PATH"]}`;
+  fs.appendFileSync(
+    process.env["GITHUB_PATH"] as string,
+    `${sysPath}${os.EOL}`,
+  );
+}
+
+/**
  * Logs an information message in GitHub Actions.
  *
  * @param message - The information message to log.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -22,6 +23,19 @@ export function getInput(name: string): string {
  */
 export async function setOutput(name: string, value: string): Promise<void> {
   await fsPromises.appendFile(
+    process.env["GITHUB_OUTPUT"] as string,
+    `${name}=${value}${os.EOL}`,
+  );
+}
+
+/**
+ * Sets the value of a GitHub Actions output synchronously.
+ *
+ * @param name - The name of the GitHub Actions output.
+ * @param value - The value to set for the GitHub Actions output.
+ */
+export function setOutputSync(name: string, value: string): void {
+  fs.appendFileSync(
     process.env["GITHUB_OUTPUT"] as string,
     `${name}=${value}${os.EOL}`,
   );


### PR DESCRIPTION
This pull request resolves #79 by adding the following new synchronous versions of asynchronous functions that are already available in this project: `setOutputSync`, `setEnvSync`, and `addPathSync`.