### PR TITLE
Modify Log Command Function to Require Variadic Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ There are various ways to log messages in GitHub Actions, including `logInfo` fo
 try {
   logInfo("some information");
   logWarning("some warning");
-  logCommand("command", ["arg0", "arg1", "arg2"]);
+  logCommand("command", "arg0", "arg1", "arg2");
 } catch (err) {
   logError(err);
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -225,7 +225,7 @@ describe("log errors in GitHub Actions", () => {
 describe("log commands in GitHub Actions", () => {
   it("should log a command in GitHub Actions", () => {
     stdoutData = "";
-    logCommand("cmd", ["arg0", "arg1", "arg2"]);
+    logCommand("cmd", "arg0", "arg1", "arg2");
     expect(stdoutData).toBe(`[command]cmd arg0 arg1 arg2${os.EOL}`);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ export function logError(err: unknown): void {
  * @param command - The command to log.
  * @param args - The arguments of the command.
  */
-export function logCommand(command: string, args: readonly string[]): void {
+export function logCommand(command: string, ...args: string[]): void {
   const message = [command, ...args].join(" ");
   process.stdout.write(`[command]${message}${os.EOL}`);
 }


### PR DESCRIPTION
This pull request resolves #81 by modifying the `logCommand` function to require variadic arguments instead of an array for the `args` parameter.