### PR TITLE
Replace "Some" Wording with "A" Wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ GitHub Actions inputs can be retrieved using the `getInput` function, which retu
 ```ts
 const input = getInput("input-name");
 
-await setOutput("output-name", "some value");
-setOutputSync("other-output-name", "some other value");
+await setOutput("output-name", "a value");
+setOutputSync("another-output-name", "another value");
 ```
 
 ### Setting Environment Variables
@@ -27,8 +27,8 @@ setOutputSync("other-output-name", "some other value");
 Environment variables in GitHub Actions can be set using the `setEnv` or `setEnvSync` functions, which sets the environment variables in the current step and exports them to the next steps:
 
 ```ts
-await setEnv("SOME_ENV", "some value");
-setEnvSync("SOME_OTHER_ENV", "some other value");
+await setEnv("AN_ENV", "a value");
+setEnvSync("ANOTHER_ENV", "another value");
 ```
 
 ### Adding System Paths
@@ -36,8 +36,8 @@ setEnvSync("SOME_OTHER_ENV", "some other value");
 System paths in the GitHub Actions environment can be added using the `addPath` or `addPathSync` functions, which prepends the given path to the system path. These functions are useful if an action is adding a new executable located in a custom path:
 
 ```ts
-await addPath("path/to/some/executable");
-addPathSync("path/to/some/executable");
+await addPath("path/to/an/executable");
+addPathSync("path/to/another/executable");
 ```
 
 ### Logging Messages
@@ -46,8 +46,8 @@ There are various ways to log messages in GitHub Actions, including `logInfo` fo
 
 ```ts
 try {
-  logInfo("some information");
-  logWarning("some warning");
+  logInfo("an information");
+  logWarning("a warning");
   logCommand("command", "arg0", "arg1", "arg2");
 } catch (err) {
   logError(err);
@@ -59,7 +59,7 @@ try {
 Logs can be grouped using the `beginLogGroup` and `endLogGroup` functions. All messages logged between the `beginLogGroup` and `endLogGroup` functions will be displayed as a group inside a collapsible line:
 
 ```ts
-beginLogGroup("some log group");
+beginLogGroup("a log group");
 logInfo("this message is inside a group");
 endLogGroup();
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -46,12 +46,13 @@ describe("retrieve environment variables", () => {
 
 describe("retrieve GitHub Actions inputs", () => {
   it("should retrieve a GitHub Actions input", () => {
-    process.env["INPUT_SOME-INPUT"] = " some value  ";
-    expect(getInput("some-input")).toBe("some value");
+    process.env["INPUT_AN-INPUT"] = " a value  ";
+    expect(getInput("an-input")).toBe("a value");
   });
 
-  it("should retrieve an empty GitHub Actions input", () => {
-    expect(getInput("some-empty-input")).toBe("");
+  it("should retrieve an undefined GitHub Actions input", () => {
+    delete process.env["INPUT_AN-UNDEFINED-INPUT"];
+    expect(getInput("an-undefined-input")).toBe("");
   });
 });
 
@@ -69,8 +70,8 @@ describe("set GitHub Actions outputs", () => {
 
   it("should set GitHub Actions outputs", async () => {
     await Promise.all([
-      setOutput("some-output", "some value"),
-      setOutput("some-other-output", "some other value"),
+      setOutput("an-output", "a value"),
+      setOutput("another-output", "another value"),
     ]);
 
     const lines = (await fsPromises.readFile(tempFile, { encoding: "utf-8" }))
@@ -79,18 +80,18 @@ describe("set GitHub Actions outputs", () => {
       .sort();
 
     expect(lines).toEqual([
-      "some-other-output=some other value",
-      "some-output=some value",
+      "an-output=a value",
+      "another-output=another value",
     ]);
   });
 
   it("should set GitHub Actions outputs synchronously", async () => {
-    setOutputSync("some-output", "some value");
-    setOutputSync("some-other-output", "some other value");
+    setOutputSync("an-output", "a value");
+    setOutputSync("another-output", "another value");
 
     const content = await fsPromises.readFile(tempFile, { encoding: "utf-8" });
     expect(content).toBe(
-      `some-output=some value${os.EOL}some-other-output=some other value${os.EOL}`,
+      `an-output=a value${os.EOL}another-output=another value${os.EOL}`,
     );
   });
 
@@ -117,34 +118,31 @@ describe("set environment variables in GitHub Actions", () => {
 
   it("should set environment variables in GitHub Actions", async () => {
     await Promise.all([
-      setEnv("SOME_ENV", "some value"),
-      setEnv("SOME_OTHER_ENV", "some other value"),
+      setEnv("AN_ENV", "a value"),
+      setEnv("ANOTHER_ENV", "another value"),
     ]);
 
-    expect(process.env.SOME_ENV).toBe("some value");
-    expect(process.env.SOME_OTHER_ENV).toBe("some other value");
+    expect(process.env.AN_ENV).toBe("a value");
+    expect(process.env.ANOTHER_ENV).toBe("another value");
 
     const lines = (await fsPromises.readFile(tempFile, { encoding: "utf-8" }))
       .split(os.EOL)
       .filter((line) => line !== "")
       .sort();
 
-    expect(lines).toEqual([
-      "SOME_ENV=some value",
-      "SOME_OTHER_ENV=some other value",
-    ]);
+    expect(lines).toEqual(["ANOTHER_ENV=another value", "AN_ENV=a value"]);
   });
 
   it("should set environment variables in GitHub Actions synchronously", async () => {
-    setEnvSync("SOME_ENV", "some value");
-    setEnvSync("SOME_OTHER_ENV", "some other value");
+    setEnvSync("AN_ENV", "a value");
+    setEnvSync("ANOTHER_ENV", "another value");
 
-    expect(process.env.SOME_ENV).toBe("some value");
-    expect(process.env.SOME_OTHER_ENV).toBe("some other value");
+    expect(process.env.AN_ENV).toBe("a value");
+    expect(process.env.ANOTHER_ENV).toBe("another value");
 
     const content = await fsPromises.readFile(tempFile, { encoding: "utf-8" });
     expect(content).toBe(
-      `SOME_ENV=some value${os.EOL}SOME_OTHER_ENV=some other value${os.EOL}`,
+      `AN_ENV=a value${os.EOL}ANOTHER_ENV=another value${os.EOL}`,
     );
   });
 
@@ -170,32 +168,32 @@ describe("adds system paths in GitHub Actions", () => {
   });
 
   it("should add system paths in GitHub Actions", async () => {
-    await Promise.all([addPath("some-path"), addPath("some-other-path")]);
+    await Promise.all([addPath("a-path"), addPath("another-path")]);
 
     const sysPaths = (process.env["PATH"] ?? "")
       .split(path.delimiter)
       .slice(0, 2)
       .sort();
-    expect(sysPaths).toEqual(["some-other-path", "some-path"]);
+    expect(sysPaths).toEqual(["a-path", "another-path"]);
 
     const lines = (await fsPromises.readFile(tempFile, { encoding: "utf-8" }))
       .split(os.EOL)
       .filter((line) => line !== "")
       .sort();
-    expect(lines).toEqual(["some-other-path", "some-path"]);
+    expect(lines).toEqual(["a-path", "another-path"]);
   });
 
   it("should add system paths in GitHub Actions synchronously", async () => {
-    addPathSync("some-path");
-    addPathSync("some-other-path");
+    addPathSync("a-path");
+    addPathSync("another-path");
 
     const sysPaths = (process.env["PATH"] ?? "")
       .split(path.delimiter)
       .slice(0, 2);
-    expect(sysPaths).toEqual(["some-other-path", "some-path"]);
+    expect(sysPaths).toEqual(["another-path", "a-path"]);
 
     const content = await fsPromises.readFile(tempFile, { encoding: "utf-8" });
-    expect(content).toBe(`some-path${os.EOL}some-other-path${os.EOL}`);
+    expect(content).toBe(`a-path${os.EOL}another-path${os.EOL}`);
   });
 
   afterEach(async () => {
@@ -210,30 +208,30 @@ describe("adds system paths in GitHub Actions", () => {
 describe("log information in GitHub Actions", () => {
   it("should log an information message in GitHub Actions", () => {
     stdoutData = "";
-    logInfo("some information message");
-    expect(stdoutData).toBe(`some information message${os.EOL}`);
+    logInfo("an information message");
+    expect(stdoutData).toBe(`an information message${os.EOL}`);
   });
 });
 
 describe("log warnings in GitHub Actions", () => {
   it("should log a warning message in GitHub Actions", () => {
     stdoutData = "";
-    logWarning("some warning message");
-    expect(stdoutData).toBe(`::warning::some warning message${os.EOL}`);
+    logWarning("a warning message");
+    expect(stdoutData).toBe(`::warning::a warning message${os.EOL}`);
   });
 });
 
 describe("log errors in GitHub Actions", () => {
   it("should log an error message in GitHub Actions", () => {
     stdoutData = "";
-    logError("some error message");
-    expect(stdoutData).toBe(`::error::some error message${os.EOL}`);
+    logError("an error message");
+    expect(stdoutData).toBe(`::error::an error message${os.EOL}`);
   });
 
   it("should log an error object in GitHub Actions", () => {
     stdoutData = "";
-    logError(new Error("some error object"));
-    expect(stdoutData).toBe(`::error::some error object${os.EOL}`);
+    logError(new Error("an error object"));
+    expect(stdoutData).toBe(`::error::an error object${os.EOL}`);
   });
 });
 
@@ -248,8 +246,8 @@ describe("log commands in GitHub Actions", () => {
 describe("begin and end log groups in GitHub Actions", () => {
   it("should begin a log group in GitHub Actions", () => {
     stdoutData = "";
-    beginLogGroup("some log group");
-    expect(stdoutData).toBe(`::group::some log group${os.EOL}`);
+    beginLogGroup("a log group");
+    expect(stdoutData).toBe(`::group::a log group${os.EOL}`);
   });
 
   it("should end the current log group in GitHub Actions", () => {


### PR DESCRIPTION
This pull request resolves #85 by replacing the incorrect "some" wording with the correct "a" and "another" wordings in the `index.test.ts` and `README.md` files.