### PR TITLE
Link Functions in Readme to API Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A minimalistic utility package for developing [GitHub Actions](https://github.co
 
 ### Getting Inputs and Setting Outputs
 
-GitHub Actions inputs can be retrieved using the `getInput` function, which returns a trimmed string or an empty string if the input is not specified. GitHub Actions outputs can be set using the `setOutput` or `setOutputSync` functions:
+GitHub Actions inputs can be retrieved using the [`getInput`](https://threeal.github.io/gha-utils/functions/getInput.html) function, which returns a trimmed string or an empty string if the input is not specified. GitHub Actions outputs can be set using the [`setOutput`](https://threeal.github.io/gha-utils/functions/setOutput.html) or [`setOutputSync`](https://threeal.github.io/gha-utils/functions/setOutputSync.html) functions:
 
 ```ts
 const input = getInput("input-name");
@@ -24,7 +24,7 @@ setOutputSync("another-output-name", "another value");
 
 ### Setting Environment Variables
 
-Environment variables in GitHub Actions can be set using the `setEnv` or `setEnvSync` functions, which sets the environment variables in the current step and exports them to the next steps:
+Environment variables in GitHub Actions can be set using the [`setEnv`](https://threeal.github.io/gha-utils/functions/setEnv.html) or [`setEnvSync`](https://threeal.github.io/gha-utils/functions/setEnvSync.html) functions, which sets the environment variables in the current step and exports them to the next steps:
 
 ```ts
 await setEnv("AN_ENV", "a value");
@@ -33,7 +33,7 @@ setEnvSync("ANOTHER_ENV", "another value");
 
 ### Adding System Paths
 
-System paths in the GitHub Actions environment can be added using the `addPath` or `addPathSync` functions, which prepends the given path to the system path. These functions are useful if an action is adding a new executable located in a custom path:
+System paths in the GitHub Actions environment can be added using the [`addPath`](https://threeal.github.io/gha-utils/functions/addPath.html) or [`addPathSync`](https://threeal.github.io/gha-utils/functions/addPathSync.html) functions, which prepends the given path to the system path. These functions are useful if an action is adding a new executable located in a custom path:
 
 ```ts
 await addPath("path/to/an/executable");
@@ -42,7 +42,7 @@ addPathSync("path/to/another/executable");
 
 ### Logging Messages
 
-There are various ways to log messages in GitHub Actions, including `logInfo` for logging an informational message, `logWarning` for logging a warning message, `logError` for logging an error message, and `logCommand` for logging a command line message:
+There are various ways to log messages in GitHub Actions, including [`logInfo`](https://threeal.github.io/gha-utils/functions/logInfo.html) for logging an informational message, [`logWarning`](https://threeal.github.io/gha-utils/functions/logWarning.html) for logging a warning message, [`logError`](https://threeal.github.io/gha-utils/functions/logError.html) for logging an error message, and [`logCommand`](https://threeal.github.io/gha-utils/functions/logCommand.html) for logging a command line message:
 
 ```ts
 try {
@@ -56,7 +56,7 @@ try {
 
 ### Grouping Logs
 
-Logs can be grouped using the `beginLogGroup` and `endLogGroup` functions. All messages logged between the `beginLogGroup` and `endLogGroup` functions will be displayed as a group inside a collapsible line:
+Logs can be grouped using the [`beginLogGroup`](https://threeal.github.io/gha-utils/functions/beginLogGroup.html) and [`endLogGroup`](https://threeal.github.io/gha-utils/functions/endLogGroup.html) functions. All messages logged between these functions will be displayed as a group within a collapsible section:
 
 ```ts
 beginLogGroup("a log group");


### PR DESCRIPTION
This pull request resolves #90 by updating the `README.md` file to include links to the API documentation for each function mentioned, providing easy access to the reference material.