### PR TITLE
Add Installation Section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ A minimalistic utility package for developing [GitHub Actions](https://github.co
 - Setting environment variables and appending system paths
 - Logging various kinds of messages
 
+## Installation
+
+This project is available as an [npm](https://www.npmjs.com/) package under the name [gha-utils](https://www.npmjs.com/package/gha-utils):
+
+```sh
+npm install gha-utils
+```
+
 ## Usage Guide
 
 ### Getting Inputs and Setting Outputs


### PR DESCRIPTION
This pull request resolves #93 by adding an installation section to the `README.md` file, explaining that the project is available as an npm package under the name [gha-utils](https://www.npmjs.com/package/gha-utils).