### PR TITLE
Add Set State Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A minimalistic utility package for developing [GitHub Actions](https://github.co
 
 - ES Module support
 - Getting inputs and setting outputs
+- Setting states
 - Setting environment variables and appending system paths
 - Logging various kinds of messages
 
@@ -28,6 +29,15 @@ const input = getInput("input-name");
 
 await setOutput("output-name", "a value");
 setOutputSync("another-output-name", "another value");
+```
+
+### Setting States
+
+GitHub Actions states are useful for passing data between the pre, main, and post steps of the same GitHub Action. States can be set using the [`setState`](https://threeal.github.io/gha-utils/functions/setState.html) or [`setStateSync`](https://threeal.github.io/gha-utils/functions/setStateSync.html) functions:
+
+```ts
+await setState("state-name", "a value");
+setStateSync("another-state-name", "another value");
 ```
 
 ### Setting Environment Variables

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-utils",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A minimalistic utility package for developing GitHub Actions",
   "keywords": [
     "github",

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -12,6 +12,7 @@ import {
   setOutput,
   setOutputSync,
   setState,
+  setStateSync,
 } from "./env.js";
 
 describe("retrieve environment variables", () => {
@@ -112,6 +113,16 @@ describe("set GitHub Actions states", () => {
       .sort();
 
     expect(lines).toEqual(["a-state=a value", "another-state=another value"]);
+  });
+
+  it("should set GitHub Actions states synchronously", async () => {
+    setStateSync("a-state", "a value");
+    setStateSync("another-state", "another value");
+
+    const content = await fsPromises.readFile(tempFile, { encoding: "utf-8" });
+    expect(content).toBe(
+      `a-state=a value${os.EOL}another-state=another value${os.EOL}`,
+    );
   });
 
   afterEach(async () => {

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -11,6 +11,7 @@ import {
   setEnvSync,
   setOutput,
   setOutputSync,
+  setState,
 } from "./env.js";
 
 describe("retrieve environment variables", () => {
@@ -76,6 +77,41 @@ describe("set GitHub Actions outputs", () => {
     expect(content).toBe(
       `an-output=a value${os.EOL}another-output=another value${os.EOL}`,
     );
+  });
+
+  afterEach(async () => {
+    try {
+      await fsPromises.rm(tempFile);
+    } catch (err) {
+      if ((err as any).code !== "ENOENT") throw err;
+    }
+  });
+});
+
+describe("set GitHub Actions states", () => {
+  let tempFile: string;
+  beforeEach(async () => {
+    tempFile = path.join(os.tmpdir(), "state");
+    process.env["GITHUB_STATE"] = tempFile;
+    try {
+      await fsPromises.rm(tempFile);
+    } catch (err) {
+      if ((err as any).code !== "ENOENT") throw err;
+    }
+  });
+
+  it("should set GitHub Actions states", async () => {
+    await Promise.all([
+      setState("a-state", "a value"),
+      setState("another-state", "another value"),
+    ]);
+
+    const lines = (await fsPromises.readFile(tempFile, { encoding: "utf-8" }))
+      .split(os.EOL)
+      .filter((line) => line !== "")
+      .sort();
+
+    expect(lines).toEqual(["a-state=a value", "another-state=another value"]);
   });
 
   afterEach(async () => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -53,6 +53,18 @@ export function setOutputSync(name: string, value: string): void {
 }
 
 /**
+ * Sets the value of a GitHub Actions state.
+ *
+ * @param name - The name of the GitHub Actions state.
+ * @param value - The value to set for the GitHub Actions state.
+ * @returns A promise that resolves when the value is successfully set.
+ */
+export async function setState(name: string, value: string): Promise<void> {
+  const filePath = mustGetEnvironment("GITHUB_STATE");
+  await fsPromises.appendFile(filePath, `${name}=${value}${os.EOL}`);
+}
+
+/**
  * Sets the value of an environment variable in GitHub Actions.
  *
  * @param name - The name of the environment variable.

--- a/src/env.ts
+++ b/src/env.ts
@@ -65,6 +65,17 @@ export async function setState(name: string, value: string): Promise<void> {
 }
 
 /**
+ * Sets the value of a GitHub Actions state synchronously.
+ *
+ * @param name - The name of the GitHub Actions state.
+ * @param value - The value to set for the GitHub Actions state.
+ */
+export function setStateSync(name: string, value: string): void {
+  const filePath = mustGetEnvironment("GITHUB_STATE");
+  fs.appendFileSync(filePath, `${name}=${value}${os.EOL}`);
+}
+
+/**
  * Sets the value of an environment variable in GitHub Actions.
  *
  * @param name - The name of the environment variable.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
   setOutput,
   setOutputSync,
   setState,
+  setStateSync,
 } from "./env.js";
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
   setEnvSync,
   setOutput,
   setOutputSync,
+  setState,
 } from "./env.js";
 
 export {


### PR DESCRIPTION
This pull request resolves #100 by adding new `setState` and `setStateSync` functions for setting GitHub Actions states. It also updates the `README.md` file to include a usage guide for the set state functions and bumps the package version to `0.4.0`.