### PR TITLE
Add Get State Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A minimalistic utility package for developing [GitHub Actions](https://github.co
 
 - ES Module support
 - Getting inputs and setting outputs
-- Setting states
+- Getting and setting states
 - Setting environment variables and appending system paths
 - Logging various kinds of messages
 
@@ -31,13 +31,19 @@ await setOutput("output-name", "a value");
 setOutputSync("another-output-name", "another value");
 ```
 
-### Setting States
+### Getting and Setting States
 
 GitHub Actions states are useful for passing data between the pre, main, and post steps of the same GitHub Action. States can be set using the [`setState`](https://threeal.github.io/gha-utils/functions/setState.html) or [`setStateSync`](https://threeal.github.io/gha-utils/functions/setStateSync.html) functions:
 
 ```ts
 await setState("state-name", "a value");
 setStateSync("another-state-name", "another value");
+```
+
+They can then be retrieved in the current or other steps using the [`getState`](https://threeal.github.io/gha-utils/functions/getState.html) function:
+
+```ts
+const state = getState("state-name");
 ```
 
 ### Setting Environment Variables

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -6,6 +6,7 @@ import {
   addPath,
   addPathSync,
   getInput,
+  getState,
   mustGetEnvironment,
   setEnv,
   setEnvSync,
@@ -89,6 +90,17 @@ describe("set GitHub Actions outputs", () => {
 
   afterAll(async () => {
     await fsPromises.rm(githubOutputFile, { force: true });
+  });
+});
+
+describe("retrieve GitHub Actions states", () => {
+  it("should retrieve a GitHub Actions state", () => {
+    process.env["STATE_A-STATE"] = " a value  ";
+    expect(getState("a-state")).toBe("a value");
+  });
+
+  it("should retrieve an undefined GitHub Actions state", () => {
+    expect(getState("an-undefined-state")).toBe("");
   });
 });
 

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -118,6 +118,12 @@ describe("set GitHub Actions states", () => {
       setState("another-state", "another value"),
     ]);
 
+    expect(process.env).toEqual({
+      GITHUB_STATE: githubStateFile,
+      "STATE_A-STATE": "a value",
+      "STATE_ANOTHER-STATE": "another value",
+    });
+
     const content = await fsPromises.readFile(githubStateFile, {
       encoding: "utf-8",
     });
@@ -133,6 +139,12 @@ describe("set GitHub Actions states", () => {
   it("should set GitHub Actions states synchronously", async () => {
     setStateSync("a-state", "a value");
     setStateSync("another-state", "another value");
+
+    expect(process.env).toEqual({
+      GITHUB_STATE: githubStateFile,
+      "STATE_A-STATE": "a value",
+      "STATE_ANOTHER-STATE": "another value",
+    });
 
     const content = await fsPromises.readFile(githubStateFile, {
       encoding: "utf-8",

--- a/src/env.ts
+++ b/src/env.ts
@@ -71,6 +71,7 @@ export function getState(name: string): string {
  * @returns A promise that resolves when the value is successfully set.
  */
 export async function setState(name: string, value: string): Promise<void> {
+  process.env[`STATE_${name.toUpperCase()}`] = value;
   const filePath = mustGetEnvironment("GITHUB_STATE");
   await fsPromises.appendFile(filePath, `${name}=${value}${os.EOL}`);
 }
@@ -82,6 +83,7 @@ export async function setState(name: string, value: string): Promise<void> {
  * @param value - The value to set for the GitHub Actions state.
  */
 export function setStateSync(name: string, value: string): void {
+  process.env[`STATE_${name.toUpperCase()}`] = value;
   const filePath = mustGetEnvironment("GITHUB_STATE");
   fs.appendFileSync(filePath, `${name}=${value}${os.EOL}`);
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -53,6 +53,17 @@ export function setOutputSync(name: string, value: string): void {
 }
 
 /**
+ * Retrieves the value of a GitHub Actions state.
+ *
+ * @param name - The name of the GitHub Actions state.
+ * @returns The value of the GitHub Actions state, or an empty string if not found.
+ */
+export function getState(name: string): string {
+  const value = process.env[`STATE_${name.toUpperCase()}`] || "";
+  return value.trim();
+}
+
+/**
  * Sets the value of a GitHub Actions state.
  *
  * @param name - The name of the GitHub Actions state.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export {
   addPath,
   addPathSync,
   getInput,
+  getState,
   setEnv,
   setEnvSync,
   setOutput,


### PR DESCRIPTION
This pull request resolves #102 by adding a new `getState` function for retrieving the state of a GitHub Action from an environment variable. It also introduces other changes, including:

- Modifying the `setState` and `setStateSync` functions to set an environment variable in addition to appending the state file, allowing the state to be accessed in the current action.
- Updating the usage in the `README.md` to include examples for the `getState` function.