### PR TITLE
Simplify File Removal in Tests

### DIFF
--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -42,11 +42,11 @@ describe("retrieve GitHub Actions inputs", () => {
 });
 
 describe("set GitHub Actions outputs", () => {
-  let tempFile: string;
+  const githubOutputFile = path.join(os.tmpdir(), "github_output");
+
   beforeEach(async () => {
-    tempFile = path.join(os.tmpdir(), "output");
-    process.env["GITHUB_OUTPUT"] = tempFile;
-    await fsPromises.rm(tempFile, { force: true });
+    process.env["GITHUB_OUTPUT"] = githubOutputFile;
+    await fsPromises.rm(githubOutputFile, { force: true });
   });
 
   it("should set GitHub Actions outputs", async () => {
@@ -55,7 +55,11 @@ describe("set GitHub Actions outputs", () => {
       setOutput("another-output", "another value"),
     ]);
 
-    const lines = (await fsPromises.readFile(tempFile, { encoding: "utf-8" }))
+    const content = await fsPromises.readFile(githubOutputFile, {
+      encoding: "utf-8",
+    });
+
+    const lines = content
       .split(os.EOL)
       .filter((line) => line !== "")
       .sort();
@@ -70,23 +74,26 @@ describe("set GitHub Actions outputs", () => {
     setOutputSync("an-output", "a value");
     setOutputSync("another-output", "another value");
 
-    const content = await fsPromises.readFile(tempFile, { encoding: "utf-8" });
+    const content = await fsPromises.readFile(githubOutputFile, {
+      encoding: "utf-8",
+    });
+
     expect(content).toBe(
       `an-output=a value${os.EOL}another-output=another value${os.EOL}`,
     );
   });
 
   afterEach(async () => {
-    await fsPromises.rm(tempFile, { force: true });
+    await fsPromises.rm(githubOutputFile, { force: true });
   });
 });
 
 describe("set GitHub Actions states", () => {
-  let tempFile: string;
+  const githubStateFile = path.join(os.tmpdir(), "github_state");
+
   beforeEach(async () => {
-    tempFile = path.join(os.tmpdir(), "state");
-    process.env["GITHUB_STATE"] = tempFile;
-    await fsPromises.rm(tempFile, { force: true });
+    process.env["GITHUB_STATE"] = githubStateFile;
+    await fsPromises.rm(githubStateFile, { force: true });
   });
 
   it("should set GitHub Actions states", async () => {
@@ -95,7 +102,11 @@ describe("set GitHub Actions states", () => {
       setState("another-state", "another value"),
     ]);
 
-    const lines = (await fsPromises.readFile(tempFile, { encoding: "utf-8" }))
+    const content = await fsPromises.readFile(githubStateFile, {
+      encoding: "utf-8",
+    });
+
+    const lines = content
       .split(os.EOL)
       .filter((line) => line !== "")
       .sort();
@@ -107,23 +118,26 @@ describe("set GitHub Actions states", () => {
     setStateSync("a-state", "a value");
     setStateSync("another-state", "another value");
 
-    const content = await fsPromises.readFile(tempFile, { encoding: "utf-8" });
+    const content = await fsPromises.readFile(githubStateFile, {
+      encoding: "utf-8",
+    });
+
     expect(content).toBe(
       `a-state=a value${os.EOL}another-state=another value${os.EOL}`,
     );
   });
 
   afterEach(async () => {
-    await fsPromises.rm(tempFile, { force: true });
+    await fsPromises.rm(githubStateFile, { force: true });
   });
 });
 
 describe("set environment variables in GitHub Actions", () => {
-  let tempFile: string;
+  const githubEnvFile = path.join(os.tmpdir(), "github_env");
+
   beforeEach(async () => {
-    tempFile = path.join(os.tmpdir(), "env");
-    process.env["GITHUB_ENV"] = tempFile;
-    await fsPromises.rm(tempFile, { force: true });
+    process.env["GITHUB_ENV"] = githubEnvFile;
+    await fsPromises.rm(githubEnvFile, { force: true });
   });
 
   it("should set environment variables in GitHub Actions", async () => {
@@ -135,7 +149,11 @@ describe("set environment variables in GitHub Actions", () => {
     expect(process.env.AN_ENV).toBe("a value");
     expect(process.env.ANOTHER_ENV).toBe("another value");
 
-    const lines = (await fsPromises.readFile(tempFile, { encoding: "utf-8" }))
+    const content = await fsPromises.readFile(githubEnvFile, {
+      encoding: "utf-8",
+    });
+
+    const lines = content
       .split(os.EOL)
       .filter((line) => line !== "")
       .sort();
@@ -150,23 +168,26 @@ describe("set environment variables in GitHub Actions", () => {
     expect(process.env.AN_ENV).toBe("a value");
     expect(process.env.ANOTHER_ENV).toBe("another value");
 
-    const content = await fsPromises.readFile(tempFile, { encoding: "utf-8" });
+    const content = await fsPromises.readFile(githubEnvFile, {
+      encoding: "utf-8",
+    });
+
     expect(content).toBe(
       `AN_ENV=a value${os.EOL}ANOTHER_ENV=another value${os.EOL}`,
     );
   });
 
   afterEach(async () => {
-    await fsPromises.rm(tempFile, { force: true });
+    await fsPromises.rm(githubEnvFile, { force: true });
   });
 });
 
 describe("adds system paths in GitHub Actions", () => {
-  let tempFile: string;
+  const githubPathFile = path.join(os.tmpdir(), "github_path");
+
   beforeEach(async () => {
-    tempFile = path.join(os.tmpdir(), "path");
-    process.env["GITHUB_PATH"] = tempFile;
-    await fsPromises.rm(tempFile, { force: true });
+    process.env["GITHUB_PATH"] = githubPathFile;
+    await fsPromises.rm(githubPathFile, { force: true });
   });
 
   it("should add system paths in GitHub Actions", async () => {
@@ -178,7 +199,11 @@ describe("adds system paths in GitHub Actions", () => {
       .sort();
     expect(sysPaths).toEqual(["a-path", "another-path"]);
 
-    const lines = (await fsPromises.readFile(tempFile, { encoding: "utf-8" }))
+    const content = await fsPromises.readFile(githubPathFile, {
+      encoding: "utf-8",
+    });
+
+    const lines = content
       .split(os.EOL)
       .filter((line) => line !== "")
       .sort();
@@ -194,11 +219,14 @@ describe("adds system paths in GitHub Actions", () => {
       .slice(0, 2);
     expect(sysPaths).toEqual(["another-path", "a-path"]);
 
-    const content = await fsPromises.readFile(tempFile, { encoding: "utf-8" });
+    const content = await fsPromises.readFile(githubPathFile, {
+      encoding: "utf-8",
+    });
+
     expect(content).toBe(`a-path${os.EOL}another-path${os.EOL}`);
   });
 
   afterEach(async () => {
-    await fsPromises.rm(tempFile, { force: true });
+    await fsPromises.rm(githubPathFile, { force: true });
   });
 });

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -83,7 +83,7 @@ describe("set GitHub Actions outputs", () => {
     );
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await fsPromises.rm(githubOutputFile, { force: true });
   });
 });
@@ -127,7 +127,7 @@ describe("set GitHub Actions states", () => {
     );
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await fsPromises.rm(githubStateFile, { force: true });
   });
 });
@@ -177,7 +177,7 @@ describe("set environment variables in GitHub Actions", () => {
     );
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await fsPromises.rm(githubEnvFile, { force: true });
   });
 });
@@ -226,7 +226,7 @@ describe("adds system paths in GitHub Actions", () => {
     expect(content).toBe(`a-path${os.EOL}another-path${os.EOL}`);
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await fsPromises.rm(githubPathFile, { force: true });
   });
 });

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -46,11 +46,7 @@ describe("set GitHub Actions outputs", () => {
   beforeEach(async () => {
     tempFile = path.join(os.tmpdir(), "output");
     process.env["GITHUB_OUTPUT"] = tempFile;
-    try {
-      await fsPromises.rm(tempFile);
-    } catch (err) {
-      if ((err as any).code !== "ENOENT") throw err;
-    }
+    await fsPromises.rm(tempFile, { force: true });
   });
 
   it("should set GitHub Actions outputs", async () => {
@@ -81,11 +77,7 @@ describe("set GitHub Actions outputs", () => {
   });
 
   afterEach(async () => {
-    try {
-      await fsPromises.rm(tempFile);
-    } catch (err) {
-      if ((err as any).code !== "ENOENT") throw err;
-    }
+    await fsPromises.rm(tempFile, { force: true });
   });
 });
 
@@ -94,11 +86,7 @@ describe("set GitHub Actions states", () => {
   beforeEach(async () => {
     tempFile = path.join(os.tmpdir(), "state");
     process.env["GITHUB_STATE"] = tempFile;
-    try {
-      await fsPromises.rm(tempFile);
-    } catch (err) {
-      if ((err as any).code !== "ENOENT") throw err;
-    }
+    await fsPromises.rm(tempFile, { force: true });
   });
 
   it("should set GitHub Actions states", async () => {
@@ -126,11 +114,7 @@ describe("set GitHub Actions states", () => {
   });
 
   afterEach(async () => {
-    try {
-      await fsPromises.rm(tempFile);
-    } catch (err) {
-      if ((err as any).code !== "ENOENT") throw err;
-    }
+    await fsPromises.rm(tempFile, { force: true });
   });
 });
 
@@ -139,11 +123,7 @@ describe("set environment variables in GitHub Actions", () => {
   beforeEach(async () => {
     tempFile = path.join(os.tmpdir(), "env");
     process.env["GITHUB_ENV"] = tempFile;
-    try {
-      await fsPromises.rm(tempFile);
-    } catch (err) {
-      if ((err as any).code !== "ENOENT") throw err;
-    }
+    await fsPromises.rm(tempFile, { force: true });
   });
 
   it("should set environment variables in GitHub Actions", async () => {
@@ -177,11 +157,7 @@ describe("set environment variables in GitHub Actions", () => {
   });
 
   afterEach(async () => {
-    try {
-      await fsPromises.rm(tempFile);
-    } catch (err) {
-      if ((err as any).code !== "ENOENT") throw err;
-    }
+    await fsPromises.rm(tempFile, { force: true });
   });
 });
 
@@ -190,11 +166,7 @@ describe("adds system paths in GitHub Actions", () => {
   beforeEach(async () => {
     tempFile = path.join(os.tmpdir(), "path");
     process.env["GITHUB_PATH"] = tempFile;
-    try {
-      await fsPromises.rm(tempFile);
-    } catch (err) {
-      if ((err as any).code !== "ENOENT") throw err;
-    }
+    await fsPromises.rm(tempFile, { force: true });
   });
 
   it("should add system paths in GitHub Actions", async () => {
@@ -227,10 +199,6 @@ describe("adds system paths in GitHub Actions", () => {
   });
 
   afterEach(async () => {
-    try {
-      await fsPromises.rm(tempFile);
-    } catch (err) {
-      if ((err as any).code !== "ENOENT") throw err;
-    }
+    await fsPromises.rm(tempFile, { force: true });
   });
 });


### PR DESCRIPTION
This pull request resolves #104 by simplifying file removal in the `env.test.ts` file. It modifies the call to the `fsPromises.rm` function with the `force` option set to `true`. Additionally, several changes were made to the test file, including renaming the temporary files and modifying the removal process to occur after all tests instead of after each test.