### PR TITLE
Prevent Add Path Functions from Appending Undefined

### DIFF
--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -227,10 +227,7 @@ describe("adds system paths in GitHub Actions", () => {
   it("should add system paths in GitHub Actions", async () => {
     await Promise.all([addPath("a-path"), addPath("another-path")]);
 
-    const sysPaths = (process.env["PATH"] ?? "")
-      .split(path.delimiter)
-      .slice(0, 2)
-      .sort();
+    const sysPaths = (process.env.PATH ?? "").split(path.delimiter).sort();
     expect(sysPaths).toEqual(["a-path", "another-path"]);
 
     const content = await fsPromises.readFile(githubPathFile, {
@@ -248,9 +245,7 @@ describe("adds system paths in GitHub Actions", () => {
     addPathSync("a-path");
     addPathSync("another-path");
 
-    const sysPaths = (process.env["PATH"] ?? "")
-      .split(path.delimiter)
-      .slice(0, 2);
+    const sysPaths = (process.env.PATH ?? "").split(path.delimiter);
     expect(sysPaths).toEqual(["another-path", "a-path"]);
 
     const content = await fsPromises.readFile(githubPathFile, {

--- a/src/env.ts
+++ b/src/env.ts
@@ -121,7 +121,11 @@ export function setEnvSync(name: string, value: string): void {
  * @returns A promise that resolves when the system path is successfully added.
  */
 export async function addPath(sysPath: string): Promise<void> {
-  process.env["PATH"] = `${sysPath}${path.delimiter}${process.env["PATH"]}`;
+  process.env.PATH =
+    process.env.PATH !== undefined
+      ? `${sysPath}${path.delimiter}${process.env.PATH}`
+      : sysPath;
+
   const filePath = mustGetEnvironment("GITHUB_PATH");
   await fsPromises.appendFile(filePath, `${sysPath}${os.EOL}`);
 }
@@ -132,7 +136,11 @@ export async function addPath(sysPath: string): Promise<void> {
  * @param sysPath - The system path to add to the environment.
  */
 export function addPathSync(sysPath: string): void {
-  process.env["PATH"] = `${sysPath}${path.delimiter}${process.env["PATH"]}`;
+  process.env.PATH =
+    process.env.PATH !== undefined
+      ? `${sysPath}${path.delimiter}${process.env.PATH}`
+      : sysPath;
+
   const filePath = mustGetEnvironment("GITHUB_PATH");
   fs.appendFileSync(filePath, `${sysPath}${os.EOL}`);
 }


### PR DESCRIPTION
This pull request resolves #108 by preventing the `addPath` and `addPathSync` functions from appending an undefined path. It also modifies the tests accordingly.