### PR TITLE
Add Log Debug Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ addPathSync("path/to/another/executable");
 
 ### Logging Messages
 
-There are various ways to log messages in GitHub Actions, including [`logInfo`](https://threeal.github.io/gha-utils/functions/logInfo.html) for logging an informational message, [`logWarning`](https://threeal.github.io/gha-utils/functions/logWarning.html) for logging a warning message, [`logError`](https://threeal.github.io/gha-utils/functions/logError.html) for logging an error message, and [`logCommand`](https://threeal.github.io/gha-utils/functions/logCommand.html) for logging a command line message:
+There are various ways to log messages in GitHub Actions, including [`logInfo`](https://threeal.github.io/gha-utils/functions/logInfo.html) for logging an informational message, [`logDebug`](https://threeal.github.io/gha-utils/functions/logDebug.html) for logging a debug message, [`logWarning`](https://threeal.github.io/gha-utils/functions/logWarning.html) for logging a warning message, [`logError`](https://threeal.github.io/gha-utils/functions/logError.html) for logging an error message, and [`logCommand`](https://threeal.github.io/gha-utils/functions/logCommand.html) for logging a command line message:
 
 ```ts
 try {
   logInfo("an information");
+  logDebug("a debug");
   logWarning("a warning");
   logCommand("command", "arg0", "arg1", "arg2");
 } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
   beginLogGroup,
   endLogGroup,
   logCommand,
+  logDebug,
   logError,
   logInfo,
   logWarning,

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -5,6 +5,7 @@ import {
   beginLogGroup,
   endLogGroup,
   logCommand,
+  logDebug,
   logError,
   logInfo,
   logWarning,
@@ -25,6 +26,14 @@ describe("log information in GitHub Actions", () => {
     stdoutData = "";
     logInfo("an information message");
     expect(stdoutData).toBe(`an information message${os.EOL}`);
+  });
+});
+
+describe("log debugs in GitHub Actions", () => {
+  it("should log a debug message in GitHub Actions", () => {
+    stdoutData = "";
+    logDebug("a debug message");
+    expect(stdoutData).toBe(`::debug::a debug message${os.EOL}`);
   });
 });
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -10,6 +10,15 @@ export function logInfo(message: string): void {
 }
 
 /**
+ * Logs a debug message in GitHub Actions.
+ *
+ * @param message - The debug message to log.
+ */
+export function logDebug(message: string): void {
+  process.stdout.write(`::debug::${message}${os.EOL}`);
+}
+
+/**
  * Logs a warning message in GitHub Actions.
  *
  * @param message - The warning message to log.


### PR DESCRIPTION
This pull request resolves #114 by adding a new `logDebug` function for logging a debug message in GitHub Actions.