### PR TITLE
Mark Internal Functions in Documentation

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 /**
+ * @internal
  * Retrieves the value of an environment variable.
  *
  * @param name - The name of the environment variable.


### PR DESCRIPTION
This pull request resolves #116 by simply marking the `mustGetEnvironment` function as an internal function in the documentation.