### PR TITLE
Refactor Stdout Mock in Tests

### DIFF
--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -12,18 +12,19 @@ import {
 } from "./log.js";
 
 let stdoutData: string;
-beforeAll(() => {
-  jest
-    .spyOn(process.stdout, "write")
-    .mockImplementation((str: string | Uint8Array): boolean => {
-      stdoutData += str;
-      return true;
-    });
+jest
+  .spyOn(process.stdout, "write")
+  .mockImplementation((str: string | Uint8Array): boolean => {
+    stdoutData += str;
+    return true;
+  });
+
+beforeEach(() => {
+  stdoutData = "";
 });
 
 describe("log information in GitHub Actions", () => {
   it("should log an information message in GitHub Actions", () => {
-    stdoutData = "";
     logInfo("an information message");
     expect(stdoutData).toBe(`an information message${os.EOL}`);
   });
@@ -31,7 +32,6 @@ describe("log information in GitHub Actions", () => {
 
 describe("log debugs in GitHub Actions", () => {
   it("should log a debug message in GitHub Actions", () => {
-    stdoutData = "";
     logDebug("a debug message");
     expect(stdoutData).toBe(`::debug::a debug message${os.EOL}`);
   });
@@ -39,7 +39,6 @@ describe("log debugs in GitHub Actions", () => {
 
 describe("log warnings in GitHub Actions", () => {
   it("should log a warning message in GitHub Actions", () => {
-    stdoutData = "";
     logWarning("a warning message");
     expect(stdoutData).toBe(`::warning::a warning message${os.EOL}`);
   });
@@ -47,13 +46,11 @@ describe("log warnings in GitHub Actions", () => {
 
 describe("log errors in GitHub Actions", () => {
   it("should log an error message in GitHub Actions", () => {
-    stdoutData = "";
     logError("an error message");
     expect(stdoutData).toBe(`::error::an error message${os.EOL}`);
   });
 
   it("should log an error object in GitHub Actions", () => {
-    stdoutData = "";
     logError(new Error("an error object"));
     expect(stdoutData).toBe(`::error::an error object${os.EOL}`);
   });
@@ -61,7 +58,6 @@ describe("log errors in GitHub Actions", () => {
 
 describe("log commands in GitHub Actions", () => {
   it("should log a command in GitHub Actions", () => {
-    stdoutData = "";
     logCommand("cmd", "arg0", "arg1", "arg2");
     expect(stdoutData).toBe(`[command]cmd arg0 arg1 arg2${os.EOL}`);
   });
@@ -69,13 +65,11 @@ describe("log commands in GitHub Actions", () => {
 
 describe("begin and end log groups in GitHub Actions", () => {
   it("should begin a log group in GitHub Actions", () => {
-    stdoutData = "";
     beginLogGroup("a log group");
     expect(stdoutData).toBe(`::group::a log group${os.EOL}`);
   });
 
   it("should end the current log group in GitHub Actions", () => {
-    stdoutData = "";
     endLogGroup();
     expect(stdoutData).toBe(`::endgroup::${os.EOL}`);
   });


### PR DESCRIPTION
This pull request resolves #118 by refactoring the `process.stdout` mock in `log.test.ts` test file.