### PR TITLE
Fix Get State Name Without Changing Case

### DIFF
--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -95,7 +95,7 @@ describe("set GitHub Actions outputs", () => {
 
 describe("retrieve GitHub Actions states", () => {
   it("should retrieve a GitHub Actions state", () => {
-    process.env["STATE_A-STATE"] = " a value  ";
+    process.env["STATE_a-state"] = " a value  ";
     expect(getState("a-state")).toBe("a value");
   });
 

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -120,8 +120,8 @@ describe("set GitHub Actions states", () => {
 
     expect(process.env).toEqual({
       GITHUB_STATE: githubStateFile,
-      "STATE_A-STATE": "a value",
-      "STATE_ANOTHER-STATE": "another value",
+      "STATE_a-state": "a value",
+      "STATE_another-state": "another value",
     });
 
     const content = await fsPromises.readFile(githubStateFile, {
@@ -142,8 +142,8 @@ describe("set GitHub Actions states", () => {
 
     expect(process.env).toEqual({
       GITHUB_STATE: githubStateFile,
-      "STATE_A-STATE": "a value",
-      "STATE_ANOTHER-STATE": "another value",
+      "STATE_a-state": "a value",
+      "STATE_another-state": "another value",
     });
 
     const content = await fsPromises.readFile(githubStateFile, {

--- a/src/env.ts
+++ b/src/env.ts
@@ -60,7 +60,7 @@ export function setOutputSync(name: string, value: string): void {
  * @returns The value of the GitHub Actions state, or an empty string if not found.
  */
 export function getState(name: string): string {
-  const value = process.env[`STATE_${name.toUpperCase()}`] ?? "";
+  const value = process.env[`STATE_${name}`] ?? "";
   return value.trim();
 }
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -72,7 +72,7 @@ export function getState(name: string): string {
  * @returns A promise that resolves when the value is successfully set.
  */
 export async function setState(name: string, value: string): Promise<void> {
-  process.env[`STATE_${name.toUpperCase()}`] = value;
+  process.env[`STATE_${name}`] = value;
   const filePath = mustGetEnvironment("GITHUB_STATE");
   await fsPromises.appendFile(filePath, `${name}=${value}${os.EOL}`);
 }
@@ -84,7 +84,7 @@ export async function setState(name: string, value: string): Promise<void> {
  * @param value - The value to set for the GitHub Actions state.
  */
 export function setStateSync(name: string, value: string): void {
-  process.env[`STATE_${name.toUpperCase()}`] = value;
+  process.env[`STATE_${name}`] = value;
   const filePath = mustGetEnvironment("GITHUB_STATE");
   fs.appendFileSync(filePath, `${name}=${value}${os.EOL}`);
 }


### PR DESCRIPTION
This pull request resolves #120 by correcting the naming case of environment variables that hold state in the `getState`, `setState`, and `setStateSync` functions.