### PR TITLE
Remove Upload Package Step in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,4 +33,4 @@ jobs:
         run: pnpm build:docs
 
       - name: Package Library
-        run: pnpm pack --out package.tgz
+        run: pnpm pack

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,11 +34,3 @@ jobs:
 
       - name: Package Library
         run: pnpm pack --out package.tgz
-
-      - name: Upload Package
-        uses: actions/upload-artifact@v4.6.1
-        with:
-          name: package
-          path: package.tgz
-          if-no-files-found: error
-          overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ dist/
 docs/
 node_modules/
 
-package.tgz
+*.tgz


### PR DESCRIPTION
This pull request resolves #298 by removing the "Upload Package" step from the `build` workflow. Additionally, this change updates the template to use the default output name for packaging the library.