### PR TITLE
Remove Unnecessary Configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,10 +6,4 @@ export default [
   ...tseslint.configs.recommended,
   ...tseslint.configs.stylistic,
   { ignores: ["dist", "docs"] },
-  {
-    files: ["**/*.test.ts"],
-    rules: {
-      "@typescript-eslint/no-explicit-any": "off",
-    },
-  },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,9 +5,7 @@ export default [
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   ...tseslint.configs.stylistic,
-  {
-    ignores: [".*", "dist", "docs"],
-  },
+  { ignores: ["dist", "docs"] },
   {
     files: ["**/*.test.ts"],
     rules: {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "prepack": "tsc",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    watch: false,
     coverage: {
       all: false,
       enabled: true,


### PR DESCRIPTION
This pull request resolves #304 by removing the following configurations:  
- Removing `.*` files from being ignored in `eslint.config.js`.  
- Removing the `watch` option set to `false` in `vitest.config.ts`.
- Removing the unnecessary `@typescript-eslint/no-explicit-any` rule in `eslint.config.js`.  