### PR TITLE
Bump Node to Version 24.0.1

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=23.11.0
+use-node-version=24.0.1

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",
-    "@tsconfig/node23": "^23.0.1",
+    "@tsconfig/node24": "^24.0.0",
     "@types/node": "^22.15.3",
     "@vitest/coverage-v8": "^3.0.7",
     "eslint": "^9.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^9.26.0
         version: 9.26.0
-      '@tsconfig/node23':
-        specifier: ^23.0.1
-        version: 23.0.1
+      '@tsconfig/node24':
+        specifier: ^24.0.0
+        version: 24.0.0
       '@types/node':
         specifier: ^22.15.3
         version: 22.15.3
@@ -436,8 +436,8 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@tsconfig/node23@23.0.1':
-    resolution: {integrity: sha512-oJ0Y42TmsBLuLAfEbPTS5JXSbJJEEU4bULROS6zsL54Gdlw5aOy27rpsquotMKGf2auP6rkbfYsjl43WdGrNcg==}
+  '@tsconfig/node24@24.0.0':
+    resolution: {integrity: sha512-3/6Cr4dELEAucgPIr6ufY7yBYMi4ttZFOewABADNZ+bm4DUZl4dup2VBcBeP1ejj3QblrWVWux/1XcRv/ZVikA==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1859,7 +1859,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@tsconfig/node23@23.0.1': {}
+  '@tsconfig/node24@24.0.0': {}
 
   '@types/estree@1.0.6': {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node23",
+  "extends": "@tsconfig/node24",
   "include": ["src"],
   "exclude": ["**/*.test.*"],
   "compilerOptions": {


### PR DESCRIPTION
This pull request bumps the Node version specified in the `.npmrc` file to version [24.0.1](https://github.com/nodejs/node/releases/tag/v24.0.1). This change also replaces @tsconfig/node23 with @tsconfig/node24.