### PR TITLE
Move Built Dependencies Config to `pnpm-workspace.yaml`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,5 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.1",
     "vitest": "^3.2.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "lefthook"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+  - lefthook


### PR DESCRIPTION
This pull request resolves #385 by moving the `onlyBuiltDependencies` config from the `package.json` file to the `pnpm-workspace.yaml` file.