### PR TITLE
Utilize TypeDoc Configuration File

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
         run: pnpm eslint
 
       - name: Check Documentation
-        run: pnpm typedoc src/index.ts --emit none --treatWarningsAsErrors
+        run: pnpm typedoc --emit none
 
       - name: Package Library
         run: pnpm pack

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
         run: pnpm install
 
       - name: Build Documentation
-        run: pnpm typedoc src/index.ts
+        run: pnpm typedoc
 
       - name: Upload Documentation
         uses: actions/upload-pages-artifact@v3.0.1

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -24,7 +24,7 @@ pre-commit:
       run: pnpm eslint --no-warn-ignored --fix {staged_files}
 
     - name: check documentation
-      run: pnpm typedoc src/index.ts --emit none --treatWarningsAsErrors
+      run: pnpm typedoc --emit none
       glob:
         - src/*.ts
         - .npmrc

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "treatWarningsAsErrors": true
+}


### PR DESCRIPTION
This pull request resolves #389 by utilizing `typedoc.json` file for configuring TypeDoc.