### PR TITLE
Remove Dependabot commit message and label configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,15 +4,9 @@ updates:
     directory: /
     schedule:
       interval: daily
-    commit-message:
-      prefix: chore
-    labels: []
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
-    commit-message:
-      prefix: chore
-    labels: []
     versioning-strategy: increase


### PR DESCRIPTION
This pull request resolves #614 by removing the custom commit message and label configuration from the `dependabot.yaml` file.
