### PR TITLE
Rename build workflow to CI and simplify workflow names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,15 +1,15 @@
-name: Build
+name: CI
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
 jobs:
-  build-library:
-    name: Build Library
+  build:
+    name: Build
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout Project
+      - name: Checkout
         uses: actions/checkout@v6.0.2
 
       - name: Install Lefthook
@@ -25,8 +25,8 @@ jobs:
       - name: Check pre-commit hook
         run: lefthook run pre-commit --all-files
 
-      - name: Test Library
+      - name: Test
         run: pnpm test
 
-      - name: Package Library
+      - name: Package
         run: pnpm pack

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
 jobs:
-  deploy-docs:
+  deploy-documentation:
     name: Deploy Documentation
     runs-on: ubuntu-24.04
     permissions:
@@ -12,12 +12,12 @@ jobs:
       pages: write
     environment:
       name: github-pages
-      url: ${{ steps.deploy-docs.outputs.page_url }}
+      url: ${{ steps.deploy-documentation.outputs.page_url }}
     concurrency:
       group: pages
       cancel-in-progress: true
     steps:
-      - name: Checkout Project
+      - name: Checkout
         uses: actions/checkout@v6.0.2
 
       - name: Setup pnpm
@@ -25,17 +25,17 @@ jobs:
         with:
           version: 10.33.4
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: pnpm install
 
-      - name: Build Documentation
+      - name: Build documentation
         run: pnpm typedoc
 
-      - name: Upload Documentation
+      - name: Upload documentation
         uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: docs
 
-      - name: Deploy Documentation
-        id: deploy-docs
+      - name: Deploy documentation
+        id: deploy-documentation
         uses: actions/deploy-pages@v5.0.0


### PR DESCRIPTION
Closes #624

## Summary

- Rename `.github/workflows/build.yaml` to `ci.yaml` with workflow name `CI`
- Simplify job and step names in both workflows (e.g. `Checkout Project` → `Checkout`, `Test Library` → `Test`)
- Rename `deploy-docs` job id to `deploy-documentation` for consistency

🤖 Generated with [Claude Code](https://claude.ai/claude-code)