### PR TITLE
Rewrite test files using test() and named imports

### DIFF
--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,7 +1,7 @@
-import fsPromises from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { readFile, rm } from "node:fs/promises";
+import { EOL, tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
   addPath,
@@ -17,56 +17,73 @@ import {
   setStateSync,
 } from "./env.js";
 
-const originalProcessEnv = { ...process.env };
+describe("mustGetEnvironment", () => {
+  afterEach(() => vi.unstubAllEnvs());
 
-beforeEach(() => {
-  process.env = {};
-});
-
-describe("retrieve environment variables", () => {
-  it("should retrieve an environment variable", () => {
-    process.env.AN_ENV = "a value";
+  test("retrieves an environment variable", () => {
+    vi.stubEnv("AN_ENV", "a value");
     expect(mustGetEnvironment("AN_ENV")).toBe("a value");
   });
 
-  it("should fail to retrieve an undefined environment variable", () => {
+  test("throws on undefined environment variable", () => {
     expect(() => mustGetEnvironment("AN_UNDEFINED_ENV")).toThrow(
       "the AN_UNDEFINED_ENV environment variable must be defined",
     );
   });
 });
 
-describe("retrieve GitHub Actions inputs", () => {
-  it("should retrieve a GitHub Actions input", () => {
-    process.env["INPUT_AN-INPUT"] = " a value  ";
+describe("getInput", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  test("retrieves a GitHub Actions input", () => {
+    vi.stubEnv("INPUT_AN-INPUT", " a value  ");
     expect(getInput("an-input")).toBe("a value");
   });
 
-  it("should retrieve an undefined GitHub Actions input", () => {
+  test("returns empty string for undefined input", () => {
     expect(getInput("an-undefined-input")).toBe("");
   });
 });
 
-describe("set GitHub Actions outputs", () => {
-  const githubOutputFile = path.join(os.tmpdir(), "github_output");
+describe("getState", () => {
+  afterEach(() => vi.unstubAllEnvs());
 
-  beforeEach(async () => {
-    process.env.GITHUB_OUTPUT = githubOutputFile;
-    await fsPromises.rm(githubOutputFile, { force: true });
+  test("retrieves a GitHub Actions state", () => {
+    vi.stubEnv("STATE_a-state", " a value  ");
+    expect(getState("a-state")).toBe("a value");
   });
 
-  it("should set GitHub Actions outputs", async () => {
+  test("returns empty string for undefined state", () => {
+    expect(getState("an-undefined-state")).toBe("");
+  });
+});
+
+describe("setOutput", () => {
+  const githubOutputFile = join(tmpdir(), "github_output");
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    savedEnv = process.env;
+    process.env = { GITHUB_OUTPUT: githubOutputFile };
+    await rm(githubOutputFile, { force: true });
+  });
+
+  afterEach(async () => {
+    process.env = savedEnv;
+    await rm(githubOutputFile, { force: true });
+  });
+
+  test("sets multiple outputs concurrently", async () => {
     await Promise.all([
       setOutput("an-output", "a value"),
       setOutput("another-output", "another value"),
     ]);
 
-    const content = await fsPromises.readFile(githubOutputFile, {
+    const content = await readFile(githubOutputFile, {
       encoding: "utf-8",
     });
-
     const lines = content
-      .split(os.EOL)
+      .split(EOL)
       .filter((line) => line !== "")
       .sort();
 
@@ -76,44 +93,36 @@ describe("set GitHub Actions outputs", () => {
     ]);
   });
 
-  it("should set GitHub Actions outputs synchronously", async () => {
+  test("sets outputs synchronously", async () => {
     setOutputSync("an-output", "a value");
     setOutputSync("another-output", "another value");
 
-    const content = await fsPromises.readFile(githubOutputFile, {
+    const content = await readFile(githubOutputFile, {
       encoding: "utf-8",
     });
 
     expect(content).toBe(
-      `an-output=a value${os.EOL}another-output=another value${os.EOL}`,
+      `an-output=a value${EOL}another-output=another value${EOL}`,
     );
   });
-
-  afterAll(async () => {
-    await fsPromises.rm(githubOutputFile, { force: true });
-  });
 });
 
-describe("retrieve GitHub Actions states", () => {
-  it("should retrieve a GitHub Actions state", () => {
-    process.env["STATE_a-state"] = " a value  ";
-    expect(getState("a-state")).toBe("a value");
-  });
-
-  it("should retrieve an undefined GitHub Actions state", () => {
-    expect(getState("an-undefined-state")).toBe("");
-  });
-});
-
-describe("set GitHub Actions states", () => {
-  const githubStateFile = path.join(os.tmpdir(), "github_state");
+describe("setState", () => {
+  const githubStateFile = join(tmpdir(), "github_state");
+  let savedEnv: NodeJS.ProcessEnv;
 
   beforeEach(async () => {
-    process.env.GITHUB_STATE = githubStateFile;
-    await fsPromises.rm(githubStateFile, { force: true });
+    savedEnv = process.env;
+    process.env = { GITHUB_STATE: githubStateFile };
+    await rm(githubStateFile, { force: true });
   });
 
-  it("should set GitHub Actions states", async () => {
+  afterEach(async () => {
+    process.env = savedEnv;
+    await rm(githubStateFile, { force: true });
+  });
+
+  test("sets multiple states concurrently", async () => {
     await Promise.all([
       setState("a-state", "a value"),
       setState("another-state", "another value"),
@@ -125,19 +134,18 @@ describe("set GitHub Actions states", () => {
       "STATE_another-state": "another value",
     });
 
-    const content = await fsPromises.readFile(githubStateFile, {
+    const content = await readFile(githubStateFile, {
       encoding: "utf-8",
     });
-
     const lines = content
-      .split(os.EOL)
+      .split(EOL)
       .filter((line) => line !== "")
       .sort();
 
     expect(lines).toEqual(["a-state=a value", "another-state=another value"]);
   });
 
-  it("should set GitHub Actions states synchronously", async () => {
+  test("sets states synchronously", async () => {
     setStateSync("a-state", "a value");
     setStateSync("another-state", "another value");
 
@@ -147,29 +155,32 @@ describe("set GitHub Actions states", () => {
       "STATE_another-state": "another value",
     });
 
-    const content = await fsPromises.readFile(githubStateFile, {
+    const content = await readFile(githubStateFile, {
       encoding: "utf-8",
     });
 
     expect(content).toBe(
-      `a-state=a value${os.EOL}another-state=another value${os.EOL}`,
+      `a-state=a value${EOL}another-state=another value${EOL}`,
     );
-  });
-
-  afterAll(async () => {
-    await fsPromises.rm(githubStateFile, { force: true });
   });
 });
 
-describe("set environment variables in GitHub Actions", () => {
-  const githubEnvFile = path.join(os.tmpdir(), "github_env");
+describe("setEnv", () => {
+  const githubEnvFile = join(tmpdir(), "github_env");
+  let savedEnv: NodeJS.ProcessEnv;
 
   beforeEach(async () => {
-    process.env.GITHUB_ENV = githubEnvFile;
-    await fsPromises.rm(githubEnvFile, { force: true });
+    savedEnv = process.env;
+    process.env = { GITHUB_ENV: githubEnvFile };
+    await rm(githubEnvFile, { force: true });
   });
 
-  it("should set environment variables in GitHub Actions", async () => {
+  afterEach(async () => {
+    process.env = savedEnv;
+    await rm(githubEnvFile, { force: true });
+  });
+
+  test("sets multiple environment variables concurrently", async () => {
     await Promise.all([
       setEnv("AN_ENV", "a value"),
       setEnv("ANOTHER_ENV", "another value"),
@@ -181,19 +192,18 @@ describe("set environment variables in GitHub Actions", () => {
       ANOTHER_ENV: "another value",
     });
 
-    const content = await fsPromises.readFile(githubEnvFile, {
+    const content = await readFile(githubEnvFile, {
       encoding: "utf-8",
     });
-
     const lines = content
-      .split(os.EOL)
+      .split(EOL)
       .filter((line) => line !== "")
       .sort();
 
     expect(lines).toEqual(["ANOTHER_ENV=another value", "AN_ENV=a value"]);
   });
 
-  it("should set environment variables in GitHub Actions synchronously", async () => {
+  test("sets environment variables synchronously", async () => {
     setEnvSync("AN_ENV", "a value");
     setEnvSync("ANOTHER_ENV", "another value");
 
@@ -203,64 +213,57 @@ describe("set environment variables in GitHub Actions", () => {
       ANOTHER_ENV: "another value",
     });
 
-    const content = await fsPromises.readFile(githubEnvFile, {
+    const content = await readFile(githubEnvFile, {
       encoding: "utf-8",
     });
 
-    expect(content).toBe(
-      `AN_ENV=a value${os.EOL}ANOTHER_ENV=another value${os.EOL}`,
-    );
-  });
-
-  afterAll(async () => {
-    await fsPromises.rm(githubEnvFile, { force: true });
+    expect(content).toBe(`AN_ENV=a value${EOL}ANOTHER_ENV=another value${EOL}`);
   });
 });
 
-describe("adds system paths in GitHub Actions", () => {
-  const githubPathFile = path.join(os.tmpdir(), "github_path");
+describe("addPath", () => {
+  const githubPathFile = join(tmpdir(), "github_path");
+  let savedEnv: NodeJS.ProcessEnv;
 
   beforeEach(async () => {
-    process.env.GITHUB_PATH = githubPathFile;
-    await fsPromises.rm(githubPathFile, { force: true });
+    savedEnv = process.env;
+    process.env = { GITHUB_PATH: githubPathFile };
+    await rm(githubPathFile, { force: true });
   });
 
-  it("should add system paths in GitHub Actions", async () => {
+  afterEach(async () => {
+    process.env = savedEnv;
+    await rm(githubPathFile, { force: true });
+  });
+
+  test("adds multiple paths concurrently", async () => {
     await Promise.all([addPath("a-path"), addPath("another-path")]);
 
-    const sysPaths = (process.env.PATH ?? "").split(path.delimiter).sort();
+    const sysPaths = (process.env.PATH ?? "").split(delimiter).sort();
     expect(sysPaths).toEqual(["a-path", "another-path"]);
 
-    const content = await fsPromises.readFile(githubPathFile, {
+    const content = await readFile(githubPathFile, {
       encoding: "utf-8",
     });
-
     const lines = content
-      .split(os.EOL)
+      .split(EOL)
       .filter((line) => line !== "")
       .sort();
+
     expect(lines).toEqual(["a-path", "another-path"]);
   });
 
-  it("should add system paths in GitHub Actions synchronously", async () => {
+  test("adds paths synchronously", async () => {
     addPathSync("a-path");
     addPathSync("another-path");
 
-    const sysPaths = (process.env.PATH ?? "").split(path.delimiter);
+    const sysPaths = (process.env.PATH ?? "").split(delimiter);
     expect(sysPaths).toEqual(["another-path", "a-path"]);
 
-    const content = await fsPromises.readFile(githubPathFile, {
+    const content = await readFile(githubPathFile, {
       encoding: "utf-8",
     });
 
-    expect(content).toBe(`a-path${os.EOL}another-path${os.EOL}`);
+    expect(content).toBe(`a-path${EOL}another-path${EOL}`);
   });
-
-  afterAll(async () => {
-    await fsPromises.rm(githubPathFile, { force: true });
-  });
-});
-
-afterAll(() => {
-  process.env = originalProcessEnv;
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
-import fsPromises from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
+import { appendFileSync } from "node:fs";
+import { appendFile } from "node:fs/promises";
+import { EOL } from "node:os";
+import { delimiter } from "node:path";
 
 /**
  * @internal
@@ -39,7 +39,7 @@ export function getInput(name: string): string {
  */
 export async function setOutput(name: string, value: string): Promise<void> {
   const filePath = mustGetEnvironment("GITHUB_OUTPUT");
-  await fsPromises.appendFile(filePath, `${name}=${value}${os.EOL}`);
+  await appendFile(filePath, `${name}=${value}${EOL}`);
 }
 
 /**
@@ -50,7 +50,7 @@ export async function setOutput(name: string, value: string): Promise<void> {
  */
 export function setOutputSync(name: string, value: string): void {
   const filePath = mustGetEnvironment("GITHUB_OUTPUT");
-  fs.appendFileSync(filePath, `${name}=${value}${os.EOL}`);
+  appendFileSync(filePath, `${name}=${value}${EOL}`);
 }
 
 /**
@@ -74,7 +74,7 @@ export function getState(name: string): string {
 export async function setState(name: string, value: string): Promise<void> {
   process.env[`STATE_${name}`] = value;
   const filePath = mustGetEnvironment("GITHUB_STATE");
-  await fsPromises.appendFile(filePath, `${name}=${value}${os.EOL}`);
+  await appendFile(filePath, `${name}=${value}${EOL}`);
 }
 
 /**
@@ -86,7 +86,7 @@ export async function setState(name: string, value: string): Promise<void> {
 export function setStateSync(name: string, value: string): void {
   process.env[`STATE_${name}`] = value;
   const filePath = mustGetEnvironment("GITHUB_STATE");
-  fs.appendFileSync(filePath, `${name}=${value}${os.EOL}`);
+  appendFileSync(filePath, `${name}=${value}${EOL}`);
 }
 
 /**
@@ -100,7 +100,7 @@ export function setStateSync(name: string, value: string): void {
 export async function setEnv(name: string, value: string): Promise<void> {
   process.env[name] = value;
   const filePath = mustGetEnvironment("GITHUB_ENV");
-  await fsPromises.appendFile(filePath, `${name}=${value}${os.EOL}`);
+  await appendFile(filePath, `${name}=${value}${EOL}`);
 }
 
 /**
@@ -112,7 +112,7 @@ export async function setEnv(name: string, value: string): Promise<void> {
 export function setEnvSync(name: string, value: string): void {
   process.env[name] = value;
   const filePath = mustGetEnvironment("GITHUB_ENV");
-  fs.appendFileSync(filePath, `${name}=${value}${os.EOL}`);
+  appendFileSync(filePath, `${name}=${value}${EOL}`);
 }
 
 /**
@@ -124,11 +124,11 @@ export function setEnvSync(name: string, value: string): void {
 export async function addPath(sysPath: string): Promise<void> {
   process.env.PATH =
     process.env.PATH !== undefined
-      ? `${sysPath}${path.delimiter}${process.env.PATH}`
+      ? `${sysPath}${delimiter}${process.env.PATH}`
       : sysPath;
 
   const filePath = mustGetEnvironment("GITHUB_PATH");
-  await fsPromises.appendFile(filePath, `${sysPath}${os.EOL}`);
+  await appendFile(filePath, `${sysPath}${EOL}`);
 }
 
 /**
@@ -139,9 +139,9 @@ export async function addPath(sysPath: string): Promise<void> {
 export function addPathSync(sysPath: string): void {
   process.env.PATH =
     process.env.PATH !== undefined
-      ? `${sysPath}${path.delimiter}${process.env.PATH}`
+      ? `${sysPath}${delimiter}${process.env.PATH}`
       : sysPath;
 
   const filePath = mustGetEnvironment("GITHUB_PATH");
-  fs.appendFileSync(filePath, `${sysPath}${os.EOL}`);
+  appendFileSync(filePath, `${sysPath}${EOL}`);
 }

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -1,5 +1,13 @@
-import os from "node:os";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EOL } from "node:os";
+import {
+  type MockInstance,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 
 import {
   beginLogGroup,
@@ -11,64 +19,66 @@ import {
   logWarning,
 } from "./log.js";
 
-let stdoutData: string;
-vi.spyOn(process.stdout, "write").mockImplementation((buffer) => {
-  if (typeof buffer === "string") stdoutData += buffer;
-  return true;
-});
+let writeSpy: MockInstance;
 
 beforeEach(() => {
-  stdoutData = "";
+  writeSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
 });
 
-describe("log information in GitHub Actions", () => {
-  it("should log an information message in GitHub Actions", () => {
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("logInfo", () => {
+  test("writes message to stdout", () => {
     logInfo("an information message");
-    expect(stdoutData).toBe(`an information message${os.EOL}`);
+    expect(writeSpy).toHaveBeenCalledWith(`an information message${EOL}`);
   });
 });
 
-describe("log debugs in GitHub Actions", () => {
-  it("should log a debug message in GitHub Actions", () => {
+describe("logDebug", () => {
+  test("writes debug command to stdout", () => {
     logDebug("a debug message");
-    expect(stdoutData).toBe(`::debug::a debug message${os.EOL}`);
+    expect(writeSpy).toHaveBeenCalledWith(`::debug::a debug message${EOL}`);
   });
 });
 
-describe("log warnings in GitHub Actions", () => {
-  it("should log a warning message in GitHub Actions", () => {
+describe("logWarning", () => {
+  test("writes warning command to stdout", () => {
     logWarning("a warning message");
-    expect(stdoutData).toBe(`::warning::a warning message${os.EOL}`);
+    expect(writeSpy).toHaveBeenCalledWith(`::warning::a warning message${EOL}`);
   });
 });
 
-describe("log errors in GitHub Actions", () => {
-  it("should log an error message in GitHub Actions", () => {
+describe("logError", () => {
+  test("writes error command for a string", () => {
     logError("an error message");
-    expect(stdoutData).toBe(`::error::an error message${os.EOL}`);
+    expect(writeSpy).toHaveBeenCalledWith(`::error::an error message${EOL}`);
   });
 
-  it("should log an error object in GitHub Actions", () => {
+  test("writes error command for an Error object", () => {
     logError(new Error("an error object"));
-    expect(stdoutData).toBe(`::error::an error object${os.EOL}`);
+    expect(writeSpy).toHaveBeenCalledWith(`::error::an error object${EOL}`);
   });
 });
 
-describe("log commands in GitHub Actions", () => {
-  it("should log a command in GitHub Actions", () => {
+describe("logCommand", () => {
+  test("writes command with arguments to stdout", () => {
     logCommand("cmd", "arg0", "arg1", "arg2");
-    expect(stdoutData).toBe(`[command]cmd arg0 arg1 arg2${os.EOL}`);
+    expect(writeSpy).toHaveBeenCalledWith(`[command]cmd arg0 arg1 arg2${EOL}`);
   });
 });
 
-describe("begin and end log groups in GitHub Actions", () => {
-  it("should begin a log group in GitHub Actions", () => {
+describe("beginLogGroup", () => {
+  test("writes group command to stdout", () => {
     beginLogGroup("a log group");
-    expect(stdoutData).toBe(`::group::a log group${os.EOL}`);
+    expect(writeSpy).toHaveBeenCalledWith(`::group::a log group${EOL}`);
   });
+});
 
-  it("should end the current log group in GitHub Actions", () => {
+describe("endLogGroup", () => {
+  test("writes endgroup command to stdout", () => {
     endLogGroup();
-    expect(stdoutData).toBe(`::endgroup::${os.EOL}`);
+    expect(writeSpy).toHaveBeenCalledWith(`::endgroup::${EOL}`);
   });
 });

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,4 +1,4 @@
-import os from "node:os";
+import { EOL } from "node:os";
 
 /**
  * Logs an information message in GitHub Actions.
@@ -6,7 +6,7 @@ import os from "node:os";
  * @param message - The information message to log.
  */
 export function logInfo(message: string): void {
-  process.stdout.write(`${message}${os.EOL}`);
+  process.stdout.write(`${message}${EOL}`);
 }
 
 /**
@@ -15,7 +15,7 @@ export function logInfo(message: string): void {
  * @param message - The debug message to log.
  */
 export function logDebug(message: string): void {
-  process.stdout.write(`::debug::${message}${os.EOL}`);
+  process.stdout.write(`::debug::${message}${EOL}`);
 }
 
 /**
@@ -24,7 +24,7 @@ export function logDebug(message: string): void {
  * @param message - The warning message to log.
  */
 export function logWarning(message: string): void {
-  process.stdout.write(`::warning::${message}${os.EOL}`);
+  process.stdout.write(`::warning::${message}${EOL}`);
 }
 
 /**
@@ -34,7 +34,7 @@ export function logWarning(message: string): void {
  */
 export function logError(err: unknown): void {
   const message = err instanceof Error ? err.message : String(err);
-  process.stdout.write(`::error::${message}${os.EOL}`);
+  process.stdout.write(`::error::${message}${EOL}`);
 }
 
 /**
@@ -45,7 +45,7 @@ export function logError(err: unknown): void {
  */
 export function logCommand(command: string, ...args: string[]): void {
   const message = [command, ...args].join(" ");
-  process.stdout.write(`[command]${message}${os.EOL}`);
+  process.stdout.write(`[command]${message}${EOL}`);
 }
 
 /**
@@ -54,12 +54,12 @@ export function logCommand(command: string, ...args: string[]): void {
  * @param name - The name of the log group.
  */
 export function beginLogGroup(name: string): void {
-  process.stdout.write(`::group::${name}${os.EOL}`);
+  process.stdout.write(`::group::${name}${EOL}`);
 }
 
 /**
  * Ends the current log group in GitHub Actions.
  */
 export function endLogGroup(): void {
-  process.stdout.write(`::endgroup::${os.EOL}`);
+  process.stdout.write(`::endgroup::${EOL}`);
 }


### PR DESCRIPTION
Closes #626

## Summary

- Replace `it("should ...")` with `test(...)` across all test files
- Use `vi.stubEnv` / `vi.unstubAllEnvs()` for simple env var mocking
- Use `vi.spyOn` per test via `beforeEach` / `vi.restoreAllMocks()` instead of a module-level mock accumulator
- Use named imports (`{ EOL }`, `{ readFile, rm }`, `{ delimiter, join }`) in both source and test files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)