### PR TITLE
Add exec function for running child processes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), set up with `
 **Source files** (in `src/`):
 
 - `env.ts` — reads inputs from `INPUT_*` env vars and appends key-value pairs to the files pointed to by `GITHUB_OUTPUT`, `GITHUB_STATE`, `GITHUB_ENV`, and `GITHUB_PATH`. Every mutating function has both an async and a sync variant.
+- `exec.ts` — wraps Node's `child_process.spawn` in a promise. Logs the command via `logCommand` and pipes stdout/stderr by default. Supports `silent` (suppress logging and piping) and `capture` (collect stdout and return it as a string) options.
 - `log.ts` — writes GitHub Actions workflow commands (`::debug::`, `::warning::`, `::error::`, `::group::`, etc.) to stdout.
 - `vars.ts` — exposes typed getter functions for every [default GitHub Actions variable](https://docs.github.com/en/actions/reference/workflows-and-actions/variables) (e.g. `getGitHubRepository()`, `getRunnerOs()`). Boolean variables return `boolean`, numeric count/day variables (`getGitHubRetentionDays`, `getGitHubRunAttempt`, `getGitHubRunNumber`) return `number`, and all others (including ID variables) return `string`.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A minimalistic utility package for developing [GitHub Actions](https://github.co
 - Getting and setting states
 - Setting environment variables and appending system paths
 - Logging various kinds of messages
+- Executing commands as child processes
 
 ## Installation
 
@@ -113,6 +114,35 @@ logInfo("this message is inside a group");
 endLogGroup();
 
 logInfo("this message is outside a group");
+```
+
+### Executing Commands
+
+The [`exec`](https://threeal.github.io/gha-utils/functions/exec.html) function runs a command as a child process. By default it logs the command via [`logCommand`](https://threeal.github.io/gha-utils/functions/logCommand.html) and pipes stdout and stderr to the current process streams:
+
+```ts
+await exec("node", ["--version"]);
+```
+
+Pass `silent: true` to suppress logging and output piping:
+
+```ts
+await exec("node", ["--version"], { silent: true });
+```
+
+Pass `capture: true` to collect stdout and return it as a string:
+
+```ts
+const { stdout } = await exec("node", ["--version"], { capture: true });
+```
+
+Both options can be combined:
+
+```ts
+const { stdout } = await exec("node", ["--version"], {
+  silent: true,
+  capture: true,
+});
 ```
 
 ## License

--- a/src/exec.test.ts
+++ b/src/exec.test.ts
@@ -1,0 +1,85 @@
+import {
+  type MockInstance,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+
+import { exec } from "./exec.js";
+import { logCommand } from "./log.js";
+
+vi.mock("./log.js");
+
+const script = "process.stdout.write('out'); process.stderr.write('err')";
+
+let stdoutWriteSpy: MockInstance;
+let stderrWriteSpy: MockInstance;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+  stderrWriteSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+function spyOutput(spy: MockInstance): string {
+  return spy.mock.calls
+    .map(([arg]) => (Buffer.isBuffer(arg) ? arg.toString() : String(arg)))
+    .join("");
+}
+
+describe("exec", () => {
+  test("rejects on failed command", async () => {
+    await expect(exec("node", ["-e", "process.exit(1)"])).rejects.toThrow(
+      'Process "node" exited with code 1',
+    );
+  });
+
+  test("executes without options", async () => {
+    await expect(exec("node", ["-e", script])).resolves.toBeUndefined();
+
+    expect(vi.mocked(logCommand).mock.calls).toStrictEqual([
+      ["node", "-e", script],
+    ]);
+
+    expect(spyOutput(stdoutWriteSpy)).toBe("out");
+    expect(spyOutput(stderrWriteSpy)).toBe("err");
+  });
+
+  test("executes with capture option", async () => {
+    await expect(
+      exec("node", ["-e", script], { capture: true }),
+    ).resolves.toStrictEqual({ stdout: "out" });
+
+    expect(vi.mocked(logCommand).mock.calls).toStrictEqual([
+      ["node", "-e", script],
+    ]);
+
+    expect(spyOutput(stdoutWriteSpy)).toBe("out");
+    expect(spyOutput(stderrWriteSpy)).toBe("err");
+  });
+
+  test("executes with silent option", async () => {
+    await expect(
+      exec("node", ["-e", script], { silent: true }),
+    ).resolves.toBeUndefined();
+
+    expect(vi.mocked(logCommand)).not.toHaveBeenCalled();
+    expect(stdoutWriteSpy).not.toHaveBeenCalled();
+    expect(stderrWriteSpy).not.toHaveBeenCalled();
+  });
+
+  test("executes with all options", async () => {
+    await expect(
+      exec("node", ["-e", script], { silent: true, capture: true }),
+    ).resolves.toStrictEqual({ stdout: "out" });
+
+    expect(vi.mocked(logCommand)).not.toHaveBeenCalled();
+    expect(stdoutWriteSpy).not.toHaveBeenCalled();
+    expect(stderrWriteSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+
+import { logCommand } from "./log.js";
+
+/**
+ * Options for configuring the behaviour of {@link exec}.
+ */
+export interface ExecOptions {
+  /**
+   * When `true`, suppresses command logging and stdout/stderr piping.
+   */
+  silent?: boolean;
+
+  /**
+   * When `true`, captures the process stdout and returns it in the resolved
+   * value.
+   */
+  capture?: boolean;
+}
+
+/**
+ * The result returned by {@link exec} when the `capture` option is enabled.
+ */
+export interface ExecResult {
+  /**
+   * The captured standard output of the process.
+   */
+  stdout: string;
+}
+
+/**
+ * Executes a command as a child process and returns the captured output.
+ *
+ * By default, logs the command using {@link logCommand} and pipes both stdout
+ * and stderr to the current process streams. Pass `silent: true` to suppress
+ * logging and piping. Stdout is also captured and returned in the resolved
+ * value.
+ *
+ * @param command - The command to execute.
+ * @param args - The arguments to pass to the command.
+ * @param opts - Options for configuring the execution behaviour, with
+ *   `capture` set to `true`.
+ * @returns A promise that resolves to an {@link ExecResult} containing the
+ *   captured stdout when the process exits successfully.
+ */
+export function exec(
+  command: string,
+  args: string[],
+  opts: ExecOptions & { capture: true },
+): Promise<ExecResult>;
+
+/**
+ * Executes a command as a child process.
+ *
+ * By default, logs the command using {@link logCommand} and pipes both stdout
+ * and stderr to the current process streams. Pass `silent: true` to suppress
+ * logging and piping, or `capture: true` to also collect and return the stdout.
+ *
+ * @param command - The command to execute.
+ * @param args - The arguments to pass to the command.
+ * @param opts - Options for configuring the execution behaviour.
+ * @returns A promise that resolves when the process exits successfully.
+ */
+export function exec(
+  command: string,
+  args: string[],
+  opts?: ExecOptions,
+): Promise<void>;
+
+export function exec(
+  command: string,
+  args: string[],
+  opts?: ExecOptions,
+): Promise<ExecResult | void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args);
+
+    if (!opts?.silent) {
+      logCommand(command, ...args);
+      proc.stdout.pipe(process.stdout);
+      proc.stderr.pipe(process.stderr);
+    }
+
+    const chunks: Uint8Array[] = [];
+    if (opts?.capture) {
+      proc.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+    }
+
+    proc.on("error", reject);
+    proc.on("close", (code: number) => {
+      if (code === 0) {
+        if (opts?.capture) {
+          resolve({ stdout: Buffer.concat(chunks).toString() });
+        } else {
+          resolve();
+        }
+      } else {
+        reject(
+          new Error(`Process "${command}" exited with code ${code.toString()}`),
+        );
+      }
+    });
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export { exec, type ExecOptions, type ExecResult } from "./exec.js";
+
 export {
   addPath,
   addPathSync,


### PR DESCRIPTION
## Summary

- Adds `exec(command, args, opts?)` in `src/exec.ts` that wraps `child_process.spawn` in a promise
- By default logs the command via `logCommand` and pipes stdout/stderr to the current process streams; pass `silent: true` to suppress
- Pass `capture: true` to collect stdout and return it as `{ stdout: string }` (overloaded for type safety)
- Exports `exec`, `ExecOptions`, and `ExecResult` from the package index
- Adds a README section and updates CLAUDE.md with the new module description

## Test plan

- [x] `pnpm tsc` passes
- [x] `pnpm test` passes with 100% coverage
- [x] Five tests cover: failed command, no options, capture option, silent option, all options — each asserting `logCommand` call, stdout/stderr piping, and return value

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)