### PR TITLE
Add addLogMask function for masking values in logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), set up with `
 
 - `env.ts` — reads inputs from `INPUT_*` env vars and appends key-value pairs to the files pointed to by `GITHUB_OUTPUT`, `GITHUB_STATE`, `GITHUB_ENV`, and `GITHUB_PATH`. Every mutating function has both an async and a sync variant.
 - `exec.ts` — wraps Node's `child_process.spawn` in a promise. Logs the command via `logCommand` and pipes stdout/stderr by default. Supports `silent` (suppress logging and piping) and `capture` (collect stdout and return it as a string) options.
-- `log.ts` — writes GitHub Actions workflow commands (`::debug::`, `::warning::`, `::error::`, `::group::`, `::stop-commands::`, etc.) to stdout.
+- `log.ts` — writes GitHub Actions workflow commands (`::debug::`, `::warning::`, `::error::`, `::add-mask::`, `::group::`, `::stop-commands::`, etc.) to stdout.
 - `vars.ts` — exposes typed getter functions for every [default GitHub Actions variable](https://docs.github.com/en/actions/reference/workflows-and-actions/variables) (e.g. `getGitHubRepository()`, `getRunnerOs()`). Boolean variables return `boolean`, numeric count/day variables (`getGitHubRetentionDays`, `getGitHubRunAttempt`, `getGitHubRunNumber`) return `number`, and all others (including ID variables) return `string`.
 
 **Testing**: Vitest with 100% coverage enforced. Tests spy on `process.stdout.write` and manipulate `process.env` to simulate the GitHub Actions runtime.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ const arch = getRunnerArch(); // "X64", "ARM64", etc.
 const isDebug = getRunnerDebug(); // true if debug logging is enabled
 ```
 
+### Masking Values in Logs
+
+Sensitive values can be masked using the [`addLogMask`](https://threeal.github.io/gha-utils/functions/addLogMask.html) function. Any subsequent occurrence of the masked value in the workflow logs will be replaced with `***`:
+
+```ts
+addLogMask(process.env.MY_SECRET);
+```
+
 ### Logging Messages
 
 There are various ways to log messages in GitHub Actions, including [`logInfo`](https://threeal.github.io/gha-utils/functions/logInfo.html) for logging an informational message, [`logDebug`](https://threeal.github.io/gha-utils/functions/logDebug.html) for logging a debug message, [`logWarning`](https://threeal.github.io/gha-utils/functions/logWarning.html) for logging a warning message, [`logError`](https://threeal.github.io/gha-utils/functions/logError.html) for logging an error message, and [`logCommand`](https://threeal.github.io/gha-utils/functions/logCommand.html) for logging a command line message:

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -11,6 +11,7 @@ import {
 } from "vitest";
 
 import {
+  addLogMask,
   beginLogGroup,
   endLogGroup,
   logCommand,
@@ -80,6 +81,15 @@ describe("logCommand", () => {
     logCommand("cmd", "arg0", "arg1", "arg2");
     expect(writeSpy.mock.calls).toStrictEqual([
       [`[command]cmd arg0 arg1 arg2${EOL}`],
+    ]);
+  });
+});
+
+describe("addLogMask", () => {
+  test("writes add-mask command to stdout", () => {
+    addLogMask("a secret value");
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [`::add-mask::a secret value${EOL}`],
     ]);
   });
 });

--- a/src/log.ts
+++ b/src/log.ts
@@ -49,6 +49,16 @@ export function logCommand(command: string, ...args: string[]): void {
 }
 
 /**
+ * Masks a value in GitHub Actions logs.
+ *
+ * @param value - The value to mask. Any occurrence of this value in subsequent
+ *   log output will be replaced with `***`.
+ */
+export function addLogMask(value: string): void {
+  process.stdout.write(`::add-mask::${value}${EOL}`);
+}
+
+/**
  * Begins a log group in GitHub Actions.
  *
  * @param name - The name of the log group.


### PR DESCRIPTION
Closes #633

## Changes

- Added `addLogMask(value: string)` to `src/log.ts` — writes the `::add-mask::` workflow command to stdout, causing GitHub Actions to redact any subsequent occurrence of the value in the log output
- Added test coverage in `src/log.test.ts`
- Documented the function in `README.md` under a new "Masking Values in Logs" section
- Updated `CLAUDE.md` to include `::add-mask::` in the `log.ts` description

🤖 Generated with [Claude Code](https://claude.com/claude-code)