### PR TITLE
Add stopCommands and resumeCommands functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), set up with `
 
 - `env.ts` — reads inputs from `INPUT_*` env vars and appends key-value pairs to the files pointed to by `GITHUB_OUTPUT`, `GITHUB_STATE`, `GITHUB_ENV`, and `GITHUB_PATH`. Every mutating function has both an async and a sync variant.
 - `exec.ts` — wraps Node's `child_process.spawn` in a promise. Logs the command via `logCommand` and pipes stdout/stderr by default. Supports `silent` (suppress logging and piping) and `capture` (collect stdout and return it as a string) options.
-- `log.ts` — writes GitHub Actions workflow commands (`::debug::`, `::warning::`, `::error::`, `::group::`, etc.) to stdout.
+- `log.ts` — writes GitHub Actions workflow commands (`::debug::`, `::warning::`, `::error::`, `::group::`, `::stop-commands::`, etc.) to stdout.
 - `vars.ts` — exposes typed getter functions for every [default GitHub Actions variable](https://docs.github.com/en/actions/reference/workflows-and-actions/variables) (e.g. `getGitHubRepository()`, `getRunnerOs()`). Boolean variables return `boolean`, numeric count/day variables (`getGitHubRetentionDays`, `getGitHubRunAttempt`, `getGitHubRunNumber`) return `number`, and all others (including ID variables) return `string`.
 
 **Testing**: Vitest with 100% coverage enforced. Tests spy on `process.stdout.write` and manipulate `process.env` to simulate the GitHub Actions runtime.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ endLogGroup();
 logInfo("this message is outside a group");
 ```
 
+### Stopping and Resuming Workflow Commands
+
+Workflow command processing can be temporarily halted using [`stopCommands`](https://threeal.github.io/gha-utils/functions/stopCommands.html) and then resumed using [`resumeCommands`](https://threeal.github.io/gha-utils/functions/resumeCommands.html). Any output between these calls will not be interpreted as workflow commands:
+
+```ts
+import { randomUUID } from "node:crypto";
+
+const endToken = randomUUID();
+stopCommands(endToken);
+// Output here is not interpreted as workflow commands
+resumeCommands(endToken);
+```
+
 ### Executing Commands
 
 The [`exec`](https://threeal.github.io/gha-utils/functions/exec.html) function runs a command as a child process. By default it logs the command via [`logCommand`](https://threeal.github.io/gha-utils/functions/logCommand.html) and pipes stdout and stderr to the current process streams:

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ export {
   logError,
   logInfo,
   logWarning,
+  resumeCommands,
+  stopCommands,
 } from "./log.js";
 
 export {

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { EOL } from "node:os";
 import {
   type MockInstance,
@@ -17,6 +18,8 @@ import {
   logError,
   logInfo,
   logWarning,
+  resumeCommands,
+  stopCommands,
 } from "./log.js";
 
 let writeSpy: MockInstance;
@@ -92,5 +95,23 @@ describe("endLogGroup", () => {
   test("writes endgroup command to stdout", () => {
     endLogGroup();
     expect(writeSpy.mock.calls).toStrictEqual([[`::endgroup::${EOL}`]]);
+  });
+});
+
+describe("stopCommands", () => {
+  test("writes stop-commands command to stdout", () => {
+    const endToken = randomUUID();
+    stopCommands(endToken);
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [`::stop-commands::${endToken}${EOL}`],
+    ]);
+  });
+});
+
+describe("resumeCommands", () => {
+  test("writes resume token to stdout", () => {
+    const endToken = randomUUID();
+    resumeCommands(endToken);
+    expect(writeSpy.mock.calls).toStrictEqual([[`::${endToken}::${EOL}`]]);
   });
 });

--- a/src/log.ts
+++ b/src/log.ts
@@ -63,3 +63,21 @@ export function beginLogGroup(name: string): void {
 export function endLogGroup(): void {
   process.stdout.write(`::endgroup::${EOL}`);
 }
+
+/**
+ * Stops processing workflow commands in GitHub Actions until resumed.
+ *
+ * @param endToken - A token used to resume command processing.
+ */
+export function stopCommands(endToken: string): void {
+  process.stdout.write(`::stop-commands::${endToken}${EOL}`);
+}
+
+/**
+ * Resumes processing workflow commands in GitHub Actions.
+ *
+ * @param endToken - The token that was used to stop command processing.
+ */
+export function resumeCommands(endToken: string): void {
+  process.stdout.write(`::${endToken}::${EOL}`);
+}


### PR DESCRIPTION
## Summary

- Adds `stopCommands(endToken)` and `resumeCommands(endToken)` to `src/log.ts`, implementing the `::stop-commands::{endToken}` and `::{endToken}::` workflow commands
- Exports both functions from `src/index.ts`
- Adds tests using `randomUUID()` from `node:crypto` for the end token
- Documents the new functions in `README.md` under a new "Stopping and Resuming Workflow Commands" section

Closes #636

## Test plan

- [x] `stopCommands` writes `::stop-commands::{endToken}` to stdout
- [x] `resumeCommands` writes `::{endToken}::` to stdout
- [x] 100% coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)