### PR TITLE
Add logNotice function and annotation options to log functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), set up with `
 
 - `env.ts` — reads inputs from `INPUT_*` env vars and appends key-value pairs to the files pointed to by `GITHUB_OUTPUT`, `GITHUB_STATE`, `GITHUB_ENV`, and `GITHUB_PATH`. Every mutating function has both an async and a sync variant.
 - `exec.ts` — wraps Node's `child_process.spawn` in a promise. Logs the command via `logCommand` and pipes stdout/stderr by default. Supports `silent` (suppress logging and piping) and `capture` (collect stdout and return it as a string) options.
-- `log.ts` — writes GitHub Actions workflow commands (`::debug::`, `::warning::`, `::error::`, `::add-mask::`, `::group::`, `::stop-commands::`, etc.) to stdout.
+- `log.ts` — writes GitHub Actions workflow commands (`::debug::`, `::notice::`, `::warning::`, `::error::`, `::add-mask::`, `::group::`, `::stop-commands::`, etc.) to stdout. `logNotice`, `logWarning`, and `logError` accept an optional `AnnotationOptions` object (`title`, `file`, `line`, `endLine`, `col`, `endColumn`) that is serialized as `key=value,...` between the command name and message.
 - `vars.ts` — exposes typed getter functions for every [default GitHub Actions variable](https://docs.github.com/en/actions/reference/workflows-and-actions/variables) (e.g. `getGitHubRepository()`, `getRunnerOs()`). Boolean variables return `boolean`, numeric count/day variables (`getGitHubRetentionDays`, `getGitHubRunAttempt`, `getGitHubRunNumber`) return `number`, and all others (including ID variables) return `string`.
 
 **Testing**: Vitest with 100% coverage enforced. Tests spy on `process.stdout.write` and manipulate `process.env` to simulate the GitHub Actions runtime.

--- a/README.md
+++ b/README.md
@@ -99,17 +99,26 @@ addLogMask(process.env.MY_SECRET);
 
 ### Logging Messages
 
-There are various ways to log messages in GitHub Actions, including [`logInfo`](https://threeal.github.io/gha-utils/functions/logInfo.html) for logging an informational message, [`logDebug`](https://threeal.github.io/gha-utils/functions/logDebug.html) for logging a debug message, [`logWarning`](https://threeal.github.io/gha-utils/functions/logWarning.html) for logging a warning message, [`logError`](https://threeal.github.io/gha-utils/functions/logError.html) for logging an error message, and [`logCommand`](https://threeal.github.io/gha-utils/functions/logCommand.html) for logging a command line message:
+There are various ways to log messages in GitHub Actions, including [`logInfo`](https://threeal.github.io/gha-utils/functions/logInfo.html) for logging an informational message, [`logDebug`](https://threeal.github.io/gha-utils/functions/logDebug.html) for logging a debug message, [`logNotice`](https://threeal.github.io/gha-utils/functions/logNotice.html) for logging a notice message, [`logWarning`](https://threeal.github.io/gha-utils/functions/logWarning.html) for logging a warning message, [`logError`](https://threeal.github.io/gha-utils/functions/logError.html) for logging an error message, and [`logCommand`](https://threeal.github.io/gha-utils/functions/logCommand.html) for logging a command line message:
 
 ```ts
 try {
   logInfo("an information");
   logDebug("a debug");
+  logNotice("a notice");
   logWarning("a warning");
   logCommand("command", "arg0", "arg1", "arg2");
 } catch (err) {
   logError(err);
 }
+```
+
+`logNotice`, `logWarning`, and `logError` accept an optional [`AnnotationOptions`](https://threeal.github.io/gha-utils/interfaces/AnnotationOptions.html) object to attach annotation metadata (source file, line number, etc.) to the log entry:
+
+```ts
+logNotice("something to note", { file: "src/index.ts", line: 42 });
+logWarning("deprecated usage", { title: "Deprecation" });
+logError(err, { file: "src/index.ts", line: 5, col: 1 });
 ```
 
 ### Grouping Logs

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,15 +14,18 @@ export {
 } from "./env.js";
 
 export {
+  addLogMask,
   beginLogGroup,
   endLogGroup,
   logCommand,
   logDebug,
   logError,
   logInfo,
+  logNotice,
   logWarning,
   resumeCommands,
   stopCommands,
+  type AnnotationOptions,
 } from "./log.js";
 
 export {

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -18,6 +18,7 @@ import {
   logDebug,
   logError,
   logInfo,
+  logNotice,
   logWarning,
   resumeCommands,
   stopCommands,
@@ -51,11 +52,80 @@ describe("logDebug", () => {
   });
 });
 
+describe("logNotice", () => {
+  test("writes notice command to stdout", () => {
+    logNotice("a notice message");
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [`::notice::a notice message${EOL}`],
+    ]);
+  });
+
+  test("writes notice command with empty options to stdout", () => {
+    logNotice("a notice message", {});
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [`::notice::a notice message${EOL}`],
+    ]);
+  });
+
+  test("writes notice command with one option to stdout", () => {
+    logNotice("a notice message", { file: "foo.ts" });
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [`::notice file=foo.ts::a notice message${EOL}`],
+    ]);
+  });
+
+  test("writes notice command with all options to stdout", () => {
+    logNotice("a notice message", {
+      title: "a title",
+      file: "foo.ts",
+      line: 1,
+      endLine: 2,
+      col: 3,
+      endColumn: 4,
+    });
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [
+        `::notice title=a title,file=foo.ts,line=1,endLine=2,col=3,endColumn=4::a notice message${EOL}`,
+      ],
+    ]);
+  });
+});
+
 describe("logWarning", () => {
   test("writes warning command to stdout", () => {
     logWarning("a warning message");
     expect(writeSpy.mock.calls).toStrictEqual([
       [`::warning::a warning message${EOL}`],
+    ]);
+  });
+
+  test("writes warning command with empty options to stdout", () => {
+    logWarning("a warning message", {});
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [`::warning::a warning message${EOL}`],
+    ]);
+  });
+
+  test("writes warning command with one option to stdout", () => {
+    logWarning("a warning message", { file: "foo.ts" });
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [`::warning file=foo.ts::a warning message${EOL}`],
+    ]);
+  });
+
+  test("writes warning command with all options to stdout", () => {
+    logWarning("a warning message", {
+      title: "a title",
+      file: "foo.ts",
+      line: 1,
+      endLine: 2,
+      col: 3,
+      endColumn: 4,
+    });
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [
+        `::warning title=a title,file=foo.ts,line=1,endLine=2,col=3,endColumn=4::a warning message${EOL}`,
+      ],
     ]);
   });
 });
@@ -72,6 +142,36 @@ describe("logError", () => {
     logError(new Error("an error object"));
     expect(writeSpy.mock.calls).toStrictEqual([
       [`::error::an error object${EOL}`],
+    ]);
+  });
+
+  test("writes error command with empty options to stdout", () => {
+    logError("an error message", {});
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [`::error::an error message${EOL}`],
+    ]);
+  });
+
+  test("writes error command with one option to stdout", () => {
+    logError("an error message", { file: "foo.ts" });
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [`::error file=foo.ts::an error message${EOL}`],
+    ]);
+  });
+
+  test("writes error command with all options to stdout", () => {
+    logError("an error message", {
+      title: "a title",
+      file: "foo.ts",
+      line: 1,
+      endLine: 2,
+      col: 3,
+      endColumn: 4,
+    });
+    expect(writeSpy.mock.calls).toStrictEqual([
+      [
+        `::error title=a title,file=foo.ts,line=1,endLine=2,col=3,endColumn=4::an error message${EOL}`,
+      ],
     ]);
   });
 });

--- a/src/log.ts
+++ b/src/log.ts
@@ -19,22 +19,63 @@ export function logDebug(message: string): void {
 }
 
 /**
+ * Optional annotation parameters for workflow commands that support annotations.
+ */
+export interface AnnotationOptions {
+  /** Custom title for the annotation. */
+  title?: string;
+  /** The filename to associate with the annotation. */
+  file?: string;
+  /** The column number to associate with the annotation. */
+  col?: number;
+  /** The end column number to associate with the annotation. */
+  endColumn?: number;
+  /** The line number to associate with the annotation. */
+  line?: number;
+  /** The end line number to associate with the annotation. */
+  endLine?: number;
+}
+
+function formatAnnotationParams(options: AnnotationOptions): string {
+  const params = Object.entries(options)
+    .filter(([, v]) => v !== undefined)
+    .map(([k, v]) => `${k}=${String(v)}`)
+    .join(",");
+  return params ? ` ${params}` : "";
+}
+
+/**
+ * Logs a notice message in GitHub Actions.
+ *
+ * @param message - The notice message to log.
+ * @param options - Optional annotation parameters.
+ */
+export function logNotice(message: string, options?: AnnotationOptions): void {
+  const params = options ? formatAnnotationParams(options) : "";
+  process.stdout.write(`::notice${params}::${message}${EOL}`);
+}
+
+/**
  * Logs a warning message in GitHub Actions.
  *
  * @param message - The warning message to log.
+ * @param options - Optional annotation parameters.
  */
-export function logWarning(message: string): void {
-  process.stdout.write(`::warning::${message}${EOL}`);
+export function logWarning(message: string, options?: AnnotationOptions): void {
+  const params = options ? formatAnnotationParams(options) : "";
+  process.stdout.write(`::warning${params}::${message}${EOL}`);
 }
 
 /**
  * Logs an error message in GitHub Actions.
  *
  * @param err - The error, which can be of any type.
+ * @param options - Optional annotation parameters.
  */
-export function logError(err: unknown): void {
+export function logError(err: unknown, options?: AnnotationOptions): void {
   const message = err instanceof Error ? err.message : String(err);
-  process.stdout.write(`::error::${message}${EOL}`);
+  const params = options ? formatAnnotationParams(options) : "";
+  process.stdout.write(`::error${params}::${message}${EOL}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add new `logNotice` function for the `::notice::` workflow command
- Add optional `AnnotationOptions` parameter to `logNotice`, `logWarning`, and `logError`, supporting `title`, `file`, `line`, `endLine`, `col`, and `endColumn`
- Export `AnnotationOptions` interface from the package

## Test plan

- [x] `logNotice`, `logWarning`, and `logError` each have tests for: no options, empty options `{}`, one option, and all options
- [x] `pnpm tsc` passes with no errors
- [x] `pnpm test` passes with 100% coverage

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)