### PR TITLE
Ignore docs directory in ESLint

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 export default defineConfig(
-  globalIgnores(["dist"]),
+  globalIgnores(["dist", "docs"]),
   eslint.configs.recommended,
   tseslint.configs.strictTypeChecked,
   tseslint.configs.stylisticTypeChecked,


### PR DESCRIPTION
## Summary

- Add `docs` to the `globalIgnores` list in `eslint.config.ts` to prevent ESLint from checking the TypeDoc-generated `docs/` directory

## Test plan

- [x] `pnpm eslint .` runs without errors from the `docs/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)