### PR TITLE
Fix null close code when exec process is terminated by a signal

### DIFF
--- a/src/exec.test.ts
+++ b/src/exec.test.ts
@@ -39,6 +39,12 @@ describe("exec", () => {
     );
   });
 
+  test("rejects on signal-killed process", async () => {
+    await expect(
+      exec("node", ["-e", "process.kill(process.pid, 'SIGTERM')"]),
+    ).rejects.toThrow('Process "node" was terminated by a signal');
+  });
+
   test("executes without options", async () => {
     await expect(exec("node", ["-e", script])).resolves.toBeUndefined();
 

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -87,7 +87,7 @@ export function exec(
     }
 
     proc.on("error", reject);
-    proc.on("close", (code: number) => {
+    proc.on("close", (code) => {
       if (code === 0) {
         if (opts?.capture) {
           resolve({ stdout: Buffer.concat(chunks).toString() });
@@ -96,7 +96,11 @@ export function exec(
         }
       } else {
         reject(
-          new Error(`Process "${command}" exited with code ${code.toString()}`),
+          new Error(
+            code !== null
+              ? `Process "${command}" exited with code ${code.toString()}`
+              : `Process "${command}" was terminated by a signal`,
+          ),
         );
       }
     });


### PR DESCRIPTION
## Summary

- Fix `close` event handler in `exec` treating `code` as `number` when Node.js types it as `number | null`
- `code` is `null` when a child process is terminated by a signal (e.g. SIGTERM, SIGKILL) rather than exiting normally
- Previously this caused a `TypeError: Cannot read properties of null (reading 'toString')` crash instead of a proper rejection
- Add a test case reproducing the signal-kill scenario

## Test plan

- [x] `pnpm test src/exec.test.ts` passes with 100% coverage
- [x] New test `rejects on signal-killed process` verifies the correct error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)