### PR TITLE
Improve documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```sh
-pnpm tsc        # type-check (no emit)
-pnpm eslint .   # lint
+pnpm tsc                 # type-check (no emit)
+pnpm eslint .            # lint
 pnpm prettier --write .  # format
-pnpm test       # run tests with coverage
-pnpm test src/io.test.ts  # run a single test file
-pnpm prepack    # compile to dist/
+pnpm typedoc --emit none # validate documentation build
+pnpm test                # run tests with coverage
+pnpm test src/io.test.ts # run a single test file
+pnpm prepack             # compile to dist/
 ```
 
 Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), set up with `lefthook install`. Hooks automatically run dependency installation, type checking, formatting, linting, and documentation validation before each commit. If formatting or linting modifies any files, the commit is aborted — stage the auto-fixed files and recommit.
@@ -22,8 +23,8 @@ Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), set up with `
 **Source files and subpath exports** (in `src/`):
 
 - `exec.ts` — wraps Node's `child_process.spawn` in a promise. Each of stdout and stderr accepts an `OutputMode`: `"inherit"` (default, passes output to the current process), `"capture"` (collects and returns the output as a string), or `"silent"` (suppresses the output). Modes can be set independently per stream.
-- `io.ts` — reads inputs from `INPUT_*` env vars and appends key-value pairs to the files pointed to by `GITHUB_OUTPUT`, `GITHUB_STATE`, `GITHUB_ENV`, and `GITHUB_PATH`. Every mutating function has both an async and a sync variant.
-- `log.ts` — writes GitHub Actions workflow commands (`::debug::`, `::notice::`, `::warning::`, `::error::`, `::add-mask::`, `::group::`, `::stop-commands::`, etc.) to stdout. `logNotice`, `logWarning`, and `logError` accept an optional `AnnotationOptions` object (`title`, `file`, `line`, `endLine`, `col`, `endColumn`) that is serialized as `key=value,...` between the command name and message.
-- `vars.ts` — exposes typed getter functions for every [default GitHub Actions variable](https://docs.github.com/en/actions/reference/workflows-and-actions/variables) (e.g. `getGitHubRepository()`, `getRunnerOs()`). Boolean variables return `boolean`, numeric count/day variables (`getGitHubRetentionDays`, `getGitHubRunAttempt`, `getGitHubRunNumber`) return `number`, and all others (including ID variables) return `string`.
+- `io.ts` — reads inputs from `INPUT_*` env vars and state from `STATE_*` env vars. Appends `name=value` pairs to `GITHUB_OUTPUT`, `GITHUB_STATE`, and `GITHUB_ENV`; appends a bare path to `GITHUB_PATH`. Every mutating function has both an async and a sync variant.
+- `log.ts` — writes to stdout. `logInfo` writes a plain message; all other log functions write GitHub Actions workflow commands (`::debug::`, `::notice::`, `::warning::`, `::error::`, `::add-mask::`, `::group::`, `::endgroup::`, `::stop-commands::`, `[command]`, etc.). `logNotice`, `logWarning`, and `logError` accept an optional `AnnotationOptions` object (`title`, `file`, `line`, `endLine`, `col`, `endColumn`) that is serialized as `key=value,...` between the command name and message.
+- `vars.ts` — exposes typed getter functions for every [default GitHub Actions variable](https://docs.github.com/en/actions/reference/workflows-and-actions/variables) (e.g. `getGitHubRepository()`, `getRunnerOs()`). Boolean variables return `boolean`, numeric count/day variables (`getGitHubRetentionDays`, `getGitHubRunAttempt`, `getGitHubRunNumber`) return `number`, context-specific variables that are only set in certain events or action types (`getGitHubActionPath`, `getGitHubActionRepository`, `getGitHubBaseRef`, `getGitHubHeadRef`) return `string | undefined`, and all others (including ID variables) return `string`. When the env var is absent, always-present string getters return `""`, numeric getters return `0`, boolean getters return `false`, and context-specific getters return `undefined`.
 
-**Testing**: Vitest with 100% coverage enforced. Tests for `log.ts` and `io.ts` spy on `process.stdout.write` and manipulate `process.env` to simulate the GitHub Actions runtime. Tests for `exec.ts` assert on resolve values but do not spy on process streams (stdout/stderr use `"inherit"` mode at the OS level, bypassing Node.js streams).
+**Testing**: Vitest with 100% coverage enforced. Tests spy on `process.stdout.write` and manipulate `process.env` to simulate the GitHub Actions runtime.

--- a/README.md
+++ b/README.md
@@ -1,90 +1,222 @@
-# GitHub Actions Utilities
+# gha-utils
 
-A minimalistic utility package for developing [GitHub Actions](https://github.com/features/actions).
-
-## Key Features
-
-- ES Module support
-- Getting inputs and setting outputs
-- Getting and setting states
-- Setting environment variables and appending system paths
-- Logging various kinds of messages
-- Executing commands as child processes
+A TypeScript utility library for building [GitHub Actions](https://github.com/features/actions). Wraps GitHub Actions' file-based and stdout-based workflow APIs into typed, promise-friendly functions, with no runtime dependencies.
 
 ## Installation
-
-This project is available as an [npm](https://www.npmjs.com/) package under the name [gha-utils](https://www.npmjs.com/package/gha-utils):
 
 ```sh
 npm install gha-utils
 ```
 
-## Usage Guide
+## Modules
 
-### Getting Inputs and Setting Outputs
+| Import                             | Purpose                                                             |
+| ---------------------------------- | ------------------------------------------------------------------- |
+| [`gha-utils/io`](#gha-utilsio)     | Read inputs; write outputs, state, env vars, and system paths       |
+| [`gha-utils/log`](#gha-utilslog)   | Log messages, mask secrets, group output, control workflow commands |
+| [`gha-utils/exec`](#gha-utilsexec) | Spawn child processes with stdout/stderr capture or suppression     |
+| [`gha-utils/vars`](#gha-utilsvars) | Typed getters for all default GitHub Actions variables              |
 
-GitHub Actions inputs can be retrieved using the [`getInput`](https://threeal.github.io/gha-utils/functions/getInput.html) function, which returns a trimmed string or an empty string if the input is not specified. GitHub Actions outputs can be set using the [`setOutput`](https://threeal.github.io/gha-utils/functions/setOutput.html) or [`setOutputSync`](https://threeal.github.io/gha-utils/functions/setOutputSync.html) functions:
+Full API reference: [threeal.github.io/gha-utils](https://threeal.github.io/gha-utils)
 
-```ts
-import { getInput, setOutput, setOutputSync } from "gha-utils/io";
+---
 
-const input = getInput("input-name");
+## `gha-utils/io`
 
-await setOutput("output-name", "a value");
-setOutputSync("another-output-name", "another value");
-```
-
-### Getting and Setting States
-
-GitHub Actions states are useful for passing data between the pre, main, and post steps of the same GitHub Action. States can be set using the [`setState`](https://threeal.github.io/gha-utils/functions/setState.html) or [`setStateSync`](https://threeal.github.io/gha-utils/functions/setStateSync.html) functions:
+### Reading inputs
 
 ```ts
-import { setState, setStateSync } from "gha-utils/io";
+import { getInput } from "gha-utils/io";
 
-await setState("state-name", "a value");
-setStateSync("another-state-name", "another value");
+const token = getInput("token"); // returns "" if the input is not set
 ```
 
-They can then be retrieved in the current or other steps using the [`getState`](https://threeal.github.io/gha-utils/functions/getState.html) function:
+### Writing outputs
 
 ```ts
-import { getState } from "gha-utils/io";
+import { setOutput } from "gha-utils/io";
 
-const state = getState("state-name");
+await setOutput("result", "success");
 ```
 
-### Setting Environment Variables
+A synchronous variant [`setOutputSync`](https://threeal.github.io/gha-utils/functions/io.setOutputSync.html) is also available.
 
-Environment variables in GitHub Actions can be set using the [`setEnv`](https://threeal.github.io/gha-utils/functions/setEnv.html) or [`setEnvSync`](https://threeal.github.io/gha-utils/functions/setEnvSync.html) functions, which sets the environment variables in the current step and exports them to the next steps:
+### State (pre/post steps)
+
+State persists across the pre, main, and post steps of the same action.
 
 ```ts
-import { setEnv, setEnvSync } from "gha-utils/io";
+import { getState, setState } from "gha-utils/io";
 
-await setEnv("AN_ENV", "a value");
-setEnvSync("ANOTHER_ENV", "another value");
+// In the main step:
+await setState("cache-key", key);
+
+// In the post step:
+const cachedKey = getState("cache-key");
 ```
 
-### Adding System Paths
+A synchronous variant [`setStateSync`](https://threeal.github.io/gha-utils/functions/io.setStateSync.html) is also available.
 
-System paths in the GitHub Actions environment can be added using the [`addPath`](https://threeal.github.io/gha-utils/functions/addPath.html) or [`addPathSync`](https://threeal.github.io/gha-utils/functions/addPathSync.html) functions, which prepends the given path to the system path. These functions are useful if an action is adding a new executable located in a custom path:
+### Environment variables
+
+Sets the variable in the current process and exports it to subsequent steps.
 
 ```ts
-import { addPath, addPathSync } from "gha-utils/io";
+import { setEnv } from "gha-utils/io";
 
-await addPath("path/to/an/executable");
-addPathSync("path/to/another/executable");
+await setEnv("MY_VAR", "value");
 ```
 
-### Accessing GitHub Actions Variables
+A synchronous variant [`setEnvSync`](https://threeal.github.io/gha-utils/functions/io.setEnvSync.html) is also available.
 
-All [default GitHub Actions variables](https://docs.github.com/en/actions/reference/workflows-and-actions/variables) are available as typed getter functions. Boolean variables return `boolean`, numeric count/day variables return `number`, and all others (including ID variables) return `string`:
+### System path
+
+Prepends the path to `PATH` in the current process and exports it to subsequent steps.
+
+```ts
+import { addPath } from "gha-utils/io";
+
+await addPath("/usr/local/custom/bin");
+```
+
+A synchronous variant [`addPathSync`](https://threeal.github.io/gha-utils/functions/io.addPathSync.html) is also available.
+
+---
+
+## `gha-utils/log`
+
+### Message levels
+
+```ts
+import {
+  logDebug,
+  logError,
+  logInfo,
+  logNotice,
+  logWarning,
+} from "gha-utils/log";
+
+logInfo("starting task");
+logDebug("verbose detail"); // only shown when debug logging is enabled
+logNotice("something worth noting");
+logWarning("non-fatal issue");
+logError("something failed");
+```
+
+`logError` accepts `unknown`, matching the type of a caught exception, so it can be passed directly in a `catch` block:
+
+```ts
+try {
+  // ...
+} catch (err) {
+  logError(err);
+}
+```
+
+`logNotice`, `logWarning`, and `logError` accept an optional [`AnnotationOptions`](https://threeal.github.io/gha-utils/interfaces/log.AnnotationOptions.html) to pin the message to a file location:
+
+```ts
+logError("type mismatch", { file: "src/index.ts", line: 42, col: 5 });
+logWarning("deprecated call", {
+  title: "Deprecation Warning",
+  file: "src/index.ts",
+  line: 10,
+});
+logNotice("review this", { file: "src/index.ts", line: 1 });
+```
+
+### Logging commands
+
+Outputs a `[command]` line to mark shell command execution in the workflow log.
+
+```ts
+import { logCommand } from "gha-utils/log";
+
+logCommand("git", "fetch", "--all"); // renders as [command]git fetch --all
+```
+
+### Masking secrets
+
+Any subsequent occurrence of the masked value in the workflow logs is replaced with `***`.
+
+```ts
+import { addLogMask } from "gha-utils/log";
+
+addLogMask(process.env.MY_SECRET ?? "");
+```
+
+### Log groups
+
+All messages logged between `beginLogGroup` and `endLogGroup` are nested inside a collapsible section.
+
+```ts
+import { beginLogGroup, endLogGroup, logInfo } from "gha-utils/log";
+
+beginLogGroup("build output");
+logInfo("compiling...");
+endLogGroup();
+```
+
+### Stopping workflow command processing
+
+Output between `stopCommands` and `resumeCommands` is not interpreted as workflow commands.
+
+```ts
+import { randomUUID } from "node:crypto";
+import { resumeCommands, stopCommands } from "gha-utils/log";
+
+const token = randomUUID();
+stopCommands(token);
+// Lines here are printed verbatim
+resumeCommands(token);
+```
+
+---
+
+## `gha-utils/exec`
+
+Runs a command as a child process. By default, passes stdout and stderr to the current process. Rejects with an `Error` if the process fails to spawn, exits with a non-zero code, or is killed by a signal.
+
+```ts
+import { exec } from "gha-utils/exec";
+
+await exec("git", ["fetch", "--all"]);
+```
+
+Set `stdout` or `stderr` to `"silent"` to suppress that stream:
+
+```ts
+await exec("git", ["fetch", "--all"], { stderr: "silent" });
+```
+
+Set either to `"capture"` to collect and return it as a string:
+
+```ts
+const { stdout } = await exec("git", ["rev-parse", "HEAD"], {
+  stdout: "capture",
+});
+```
+
+Both streams can also be captured at once:
+
+```ts
+const { stdout, stderr } = await exec("git", ["rev-parse", "HEAD"], {
+  stdout: "capture",
+  stderr: "capture",
+});
+```
+
+---
+
+## `gha-utils/vars`
+
+Typed getters for every [default GitHub Actions variable](https://docs.github.com/en/actions/reference/workflows-and-actions/variables). Boolean variables return `boolean`, numeric count/day variables return `number`, context-specific variables (only set in certain events or action types) return `string | undefined`, and all others return `string`.
 
 ```ts
 import {
   getCI,
   getGitHubEventName,
   getGitHubRefName,
-  getGitHubRefProtected,
   getGitHubRepository,
   getGitHubRunAttempt,
   getGitHubRunId,
@@ -95,137 +227,25 @@ import {
   getRunnerOs,
 } from "gha-utils/vars";
 
-// Context
-const repo = getGitHubRepository(); // e.g. "octocat/Hello-World"
+const repo = getGitHubRepository(); // "owner/repo"
 const sha = getGitHubSha(); // triggering commit SHA
-const refName = getGitHubRefName(); // e.g. "main"
-const eventName = getGitHubEventName(); // e.g. "push"
-const isCI = getCI(); // true when running in CI
-const isProtected = getGitHubRefProtected(); // true if branch is protected
-
-// Run metadata
-const runId = getGitHubRunId(); // unique run ID (string)
-const runNumber = getGitHubRunNumber(); // sequential run number (number)
-const runAttempt = getGitHubRunAttempt(); // attempt count (number)
-
-// Runner info
+const ref = getGitHubRefName(); // e.g. "main"
+const event = getGitHubEventName(); // e.g. "push"
+const isCI = getCI(); // boolean
+const runId = getGitHubRunId(); // e.g. "1234567890"
+const runNumber = getGitHubRunNumber(); // number
+const runAttempt = getGitHubRunAttempt(); // number
 const os = getRunnerOs(); // "Linux", "Windows", or "macOS"
 const arch = getRunnerArch(); // "X64", "ARM64", etc.
-const isDebug = getRunnerDebug(); // true if debug logging is enabled
+const isDebug = getRunnerDebug(); // boolean
 ```
 
-### Masking Values in Logs
+For the full list of available getters, see the [API reference](https://threeal.github.io/gha-utils/modules/vars.html).
 
-Sensitive values can be masked using the [`addLogMask`](https://threeal.github.io/gha-utils/functions/addLogMask.html) function. Any subsequent occurrence of the masked value in the workflow logs will be replaced with `***`:
-
-```ts
-import { addLogMask } from "gha-utils/log";
-
-addLogMask(process.env.MY_SECRET);
-```
-
-### Logging Messages
-
-There are various ways to log messages in GitHub Actions, including [`logInfo`](https://threeal.github.io/gha-utils/functions/logInfo.html) for logging an informational message, [`logDebug`](https://threeal.github.io/gha-utils/functions/logDebug.html) for logging a debug message, [`logNotice`](https://threeal.github.io/gha-utils/functions/logNotice.html) for logging a notice message, [`logWarning`](https://threeal.github.io/gha-utils/functions/logWarning.html) for logging a warning message, [`logError`](https://threeal.github.io/gha-utils/functions/logError.html) for logging an error message, and [`logCommand`](https://threeal.github.io/gha-utils/functions/logCommand.html) for logging a command line message:
-
-```ts
-import {
-  logCommand,
-  logDebug,
-  logError,
-  logInfo,
-  logNotice,
-  logWarning,
-} from "gha-utils/log";
-
-try {
-  logInfo("an information");
-  logDebug("a debug");
-  logNotice("a notice");
-  logWarning("a warning");
-  logCommand("command", "arg0", "arg1", "arg2");
-} catch (err) {
-  logError(err);
-}
-```
-
-`logNotice`, `logWarning`, and `logError` accept an optional [`AnnotationOptions`](https://threeal.github.io/gha-utils/interfaces/AnnotationOptions.html) object to attach annotation metadata (source file, line number, etc.) to the log entry:
-
-```ts
-import { logError, logNotice, logWarning } from "gha-utils/log";
-
-logNotice("something to note", { file: "src/index.ts", line: 42 });
-logWarning("deprecated usage", { title: "Deprecation" });
-logError("something went wrong", { file: "src/index.ts", line: 5, col: 1 });
-```
-
-### Grouping Logs
-
-Logs can be grouped using the [`beginLogGroup`](https://threeal.github.io/gha-utils/functions/beginLogGroup.html) and [`endLogGroup`](https://threeal.github.io/gha-utils/functions/endLogGroup.html) functions. All messages logged between these functions will be displayed as a group within a collapsible section:
-
-```ts
-import { beginLogGroup, endLogGroup, logInfo } from "gha-utils/log";
-
-beginLogGroup("a log group");
-logInfo("this message is inside a group");
-endLogGroup();
-
-logInfo("this message is outside a group");
-```
-
-### Stopping and Resuming Workflow Commands
-
-Workflow command processing can be temporarily halted using [`stopCommands`](https://threeal.github.io/gha-utils/functions/stopCommands.html) and then resumed using [`resumeCommands`](https://threeal.github.io/gha-utils/functions/resumeCommands.html). Any output between these calls will not be interpreted as workflow commands:
-
-```ts
-import { randomUUID } from "node:crypto";
-import { resumeCommands, stopCommands } from "gha-utils/log";
-
-const endToken = randomUUID();
-stopCommands(endToken);
-// Output here is not interpreted as workflow commands
-resumeCommands(endToken);
-```
-
-### Executing Commands
-
-The [`exec`](https://threeal.github.io/gha-utils/functions/exec.html) function runs a command as a child process. By default, both stdout and stderr use `"inherit"` mode, passing the output to the current process:
-
-```ts
-import { exec } from "gha-utils/exec";
-
-await exec("node", ["--version"]);
-```
-
-Set `stdout` or `stderr` to `"silent"` to suppress that stream:
-
-```ts
-import { exec } from "gha-utils/exec";
-
-await exec("node", ["--version"], { stdout: "silent", stderr: "silent" });
-```
-
-Set either to `"capture"` to collect and return it as a string:
-
-```ts
-import { exec } from "gha-utils/exec";
-
-const { stdout } = await exec("node", ["--version"], { stdout: "capture" });
-```
-
-Both streams can be captured independently:
-
-```ts
-import { exec } from "gha-utils/exec";
-
-const { stdout, stderr } = await exec("node", ["--version"], {
-  stdout: "capture",
-  stderr: "capture",
-});
-```
+---
 
 ## License
 
-This project is licensed under the terms of the [MIT License](./LICENSE).
+This project is licensed under the [MIT License](./LICENSE).
 
-Copyright © 2024-2026 [Alfi Maulana](https://github.com/threeal)
+Copyright © 2024–2026 [Alfi Maulana](https://github.com/threeal)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gha-utils",
   "version": "0.4.1",
-  "description": "A minimalistic utility package for developing GitHub Actions",
+  "description": "A utility library for building GitHub Actions with no runtime dependencies",
   "keywords": [
     "github",
     "actions",

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -10,7 +10,7 @@ import { spawn } from "node:child_process";
 export type OutputMode = "inherit" | "capture" | "silent";
 
 /**
- * Options for configuring the behaviour of {@link exec}.
+ * Options for configuring the behavior of {@link exec}.
  */
 export interface ExecOptions {
   /**
@@ -35,6 +35,8 @@ export interface ExecOptions {
  * @param opts - Options with both `stdout` and `stderr` set to `"capture"`.
  * @returns A promise that resolves to an object containing the captured stdout
  *   and stderr when the process exits successfully.
+ * @throws An `Error` if the process fails to spawn, exits with a non-zero
+ *   code, or is terminated by a signal.
  */
 export function exec(
   command: string,
@@ -46,13 +48,17 @@ export function exec(
  * Executes a command as a child process, capturing stdout.
  *
  * stdout is collected and returned as a string instead of being passed to the
- * current process. stderr defaults to `"inherit"`.
+ * current process. stderr uses `"inherit"` mode by default, passing the output
+ * to the current process; set it to `"silent"` to suppress it, or `"capture"`
+ * to also collect it as a string (see the both-capture overload).
  *
  * @param command - The command to execute.
  * @param args - The arguments to pass to the command.
  * @param opts - Options with `stdout` set to `"capture"`.
  * @returns A promise that resolves to an object containing the captured stdout
  *   when the process exits successfully.
+ * @throws An `Error` if the process fails to spawn, exits with a non-zero
+ *   code, or is terminated by a signal.
  */
 export function exec(
   command: string,
@@ -64,13 +70,17 @@ export function exec(
  * Executes a command as a child process, capturing stderr.
  *
  * stderr is collected and returned as a string instead of being passed to the
- * current process. stdout defaults to `"inherit"`.
+ * current process. stdout uses `"inherit"` mode by default, passing the output
+ * to the current process; set it to `"silent"` to suppress it, or `"capture"`
+ * to also collect it as a string (see the both-capture overload).
  *
  * @param command - The command to execute.
  * @param args - The arguments to pass to the command.
  * @param opts - Options with `stderr` set to `"capture"`.
  * @returns A promise that resolves to an object containing the captured stderr
  *   when the process exits successfully.
+ * @throws An `Error` if the process fails to spawn, exits with a non-zero
+ *   code, or is terminated by a signal.
  */
 export function exec(
   command: string,
@@ -83,12 +93,14 @@ export function exec(
  *
  * By default, both stdout and stderr use `"inherit"` mode, passing the output
  * to the current process. Set either to `"silent"` to suppress the output, or
- * `"capture"` to collect and return it as a string.
+ * `"capture"` to collect and return it as a string (see the capture overloads).
  *
  * @param command - The command to execute.
  * @param args - The arguments to pass to the command.
- * @param opts - Options for configuring the execution behaviour.
+ * @param opts - Options for configuring the execution behavior.
  * @returns A promise that resolves when the process exits successfully.
+ * @throws An `Error` if the process fails to spawn, exits with a non-zero
+ *   code, or is terminated by a signal.
  */
 export function exec(
   command: string,

--- a/src/io.ts
+++ b/src/io.ts
@@ -13,8 +13,11 @@ import {
 /**
  * Retrieves the value of a GitHub Actions input.
  *
+ * Input names are matched case-insensitively — `getInput("token")` and
+ * `getInput("TOKEN")` both read the same `INPUT_TOKEN` env var.
+ *
  * @param name - The name of the GitHub Actions input.
- * @returns The value of the GitHub Actions input, or an empty string if not found.
+ * @returns The trimmed value of the GitHub Actions input, or an empty string if not set.
  */
 export function getInput(name: string): string {
   const value = process.env[`INPUT_${name.toUpperCase()}`] ?? "";
@@ -23,6 +26,9 @@ export function getInput(name: string): string {
 
 /**
  * Sets the value of a GitHub Actions output.
+ *
+ * Appends the value to the output file so it is available to subsequent steps
+ * in the workflow.
  *
  * @param name - The name of the GitHub Actions output.
  * @param value - The value to set for the GitHub Actions output.
@@ -35,6 +41,9 @@ export async function setOutput(name: string, value: string): Promise<void> {
 /**
  * Sets the value of a GitHub Actions output synchronously.
  *
+ * Appends the value to the output file so it is available to subsequent steps
+ * in the workflow.
+ *
  * @param name - The name of the GitHub Actions output.
  * @param value - The value to set for the GitHub Actions output.
  */
@@ -45,8 +54,11 @@ export function setOutputSync(name: string, value: string): void {
 /**
  * Retrieves the value of a GitHub Actions state.
  *
+ * State names are case-sensitive — use the exact same casing that was passed
+ * to {@link setState}.
+ *
  * @param name - The name of the GitHub Actions state.
- * @returns The value of the GitHub Actions state, or an empty string if not found.
+ * @returns The trimmed value of the GitHub Actions state, or an empty string if not set.
  */
 export function getState(name: string): string {
   const value = process.env[`STATE_${name}`] ?? "";
@@ -55,6 +67,9 @@ export function getState(name: string): string {
 
 /**
  * Sets the value of a GitHub Actions state.
+ *
+ * Makes the state available in the current process and persists it across
+ * the pre, main, and post steps of the same action.
  *
  * @param name - The name of the GitHub Actions state.
  * @param value - The value to set for the GitHub Actions state.
@@ -68,6 +83,9 @@ export async function setState(name: string, value: string): Promise<void> {
 /**
  * Sets the value of a GitHub Actions state synchronously.
  *
+ * Makes the state available in the current process and persists it across
+ * the pre, main, and post steps of the same action.
+ *
  * @param name - The name of the GitHub Actions state.
  * @param value - The value to set for the GitHub Actions state.
  */
@@ -79,10 +97,12 @@ export function setStateSync(name: string, value: string): void {
 /**
  * Sets the value of an environment variable in GitHub Actions.
  *
+ * Updates `process.env` immediately so the variable is available in the
+ * current process, and appends it to the env file for subsequent steps.
+ *
  * @param name - The name of the environment variable.
  * @param value - The value to set for the environment variable.
- * @returns A promise that resolves when the environment variable is
- *          successfully set.
+ * @returns A promise that resolves when the environment variable is successfully set.
  */
 export async function setEnv(name: string, value: string): Promise<void> {
   process.env[name] = value;
@@ -91,6 +111,9 @@ export async function setEnv(name: string, value: string): Promise<void> {
 
 /**
  * Sets the value of an environment variable in GitHub Actions synchronously.
+ *
+ * Updates `process.env` immediately so the variable is available in the
+ * current process, and appends it to the env file for subsequent steps.
  *
  * @param name - The name of the environment variable.
  * @param value - The value to set for the environment variable.
@@ -102,6 +125,9 @@ export function setEnvSync(name: string, value: string): void {
 
 /**
  * Adds a system path to the environment in GitHub Actions.
+ *
+ * Prepends the path to `process.env.PATH` immediately so it is available in
+ * the current process, and appends it to the path file for subsequent steps.
  *
  * @param sysPath - The system path to add to the environment.
  * @returns A promise that resolves when the system path is successfully added.
@@ -117,6 +143,9 @@ export async function addPath(sysPath: string): Promise<void> {
 
 /**
  * Adds a system path to the environment in GitHub Actions synchronously.
+ *
+ * Prepends the path to `process.env.PATH` immediately so it is available in
+ * the current process, and appends it to the path file for subsequent steps.
  *
  * @param sysPath - The system path to add to the environment.
  */

--- a/src/log.ts
+++ b/src/log.ts
@@ -22,18 +22,38 @@ export function logDebug(message: string): void {
  * Optional annotation parameters for workflow commands that support annotations.
  */
 export interface AnnotationOptions {
-  /** Custom title for the annotation. */
+  /**
+   * Custom title displayed in the annotation header.
+   */
   title?: string;
-  /** The filename to associate with the annotation. */
+
+  /**
+   * Path to the file associated with the annotation, relative to the repository root.
+   */
   file?: string;
-  /** The column number to associate with the annotation. */
-  col?: number;
-  /** The end column number to associate with the annotation. */
-  endColumn?: number;
-  /** The line number to associate with the annotation. */
+
+  /**
+   * Starting line number of the annotation within the file.
+   */
   line?: number;
-  /** The end line number to associate with the annotation. */
+
+  /**
+   * Ending line number of the annotation within the file.
+   */
   endLine?: number;
+
+  /**
+   * Starting column number of the annotation within the file.
+   *
+   * Named `col` (not `column`) to match GitHub's workflow command parameter name,
+   * which uses `col` for the start and `endColumn` for the end.
+   */
+  col?: number;
+
+  /**
+   * Ending column number of the annotation within the file.
+   */
+  endColumn?: number;
 }
 
 function formatAnnotationParams(options: AnnotationOptions): string {
@@ -48,7 +68,7 @@ function formatAnnotationParams(options: AnnotationOptions): string {
  * Logs a notice message in GitHub Actions.
  *
  * @param message - The notice message to log.
- * @param options - Optional annotation parameters.
+ * @param options - Optional annotation parameters to pin the message to a file location.
  */
 export function logNotice(message: string, options?: AnnotationOptions): void {
   const params = options ? formatAnnotationParams(options) : "";
@@ -59,7 +79,7 @@ export function logNotice(message: string, options?: AnnotationOptions): void {
  * Logs a warning message in GitHub Actions.
  *
  * @param message - The warning message to log.
- * @param options - Optional annotation parameters.
+ * @param options - Optional annotation parameters to pin the message to a file location.
  */
 export function logWarning(message: string, options?: AnnotationOptions): void {
   const params = options ? formatAnnotationParams(options) : "";
@@ -70,7 +90,7 @@ export function logWarning(message: string, options?: AnnotationOptions): void {
  * Logs an error message in GitHub Actions.
  *
  * @param err - The error, which can be of any type.
- * @param options - Optional annotation parameters.
+ * @param options - Optional annotation parameters to pin the message to a file location.
  */
 export function logError(err: unknown, options?: AnnotationOptions): void {
   const message = err instanceof Error ? err.message : String(err);
@@ -100,7 +120,7 @@ export function addLogMask(value: string): void {
 }
 
 /**
- * Begins a log group in GitHub Actions.
+ * Begins a log group in GitHub Actions. Close it with {@link endLogGroup}.
  *
  * @param name - The name of the log group.
  */
@@ -109,25 +129,27 @@ export function beginLogGroup(name: string): void {
 }
 
 /**
- * Ends the current log group in GitHub Actions.
+ * Ends the log group opened by {@link beginLogGroup}.
  */
 export function endLogGroup(): void {
   process.stdout.write(`::endgroup::${EOL}`);
 }
 
 /**
- * Stops processing workflow commands in GitHub Actions until resumed.
+ * Stops processing workflow commands in GitHub Actions until
+ * {@link resumeCommands} is called with the same token.
  *
- * @param endToken - A token used to resume command processing.
+ * @param endToken - A unique token identifying this stop/resume pair.
  */
 export function stopCommands(endToken: string): void {
   process.stdout.write(`::stop-commands::${endToken}${EOL}`);
 }
 
 /**
- * Resumes processing workflow commands in GitHub Actions.
+ * Resumes processing workflow commands in GitHub Actions after
+ * {@link stopCommands} was called with the same token.
  *
- * @param endToken - The token that was used to stop command processing.
+ * @param endToken - The token that was passed to {@link stopCommands}.
  */
 export function resumeCommands(endToken: string): void {
   process.stdout.write(`::${endToken}::${EOL}`);

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -13,7 +13,8 @@ export function getCI(): boolean {
  * For scripts without an ID, GitHub uses `__run`. Repeated invocations get
  * numeric suffixes (e.g. `__run_2`).
  *
- * @returns The name or ID of the currently running action or step.
+ * @returns The name or ID of the currently running action or step, or an
+ *   empty string if not set.
  */
 export function getGitHubAction(): string {
   return process.env.GITHUB_ACTION ?? "";
@@ -59,7 +60,7 @@ export function getGitHubActions(): boolean {
 /**
  * Returns the username of the person or app that triggered the workflow.
  *
- * @returns The actor's username.
+ * @returns The actor's username, or an empty string if not set.
  */
 export function getGitHubActor(): string {
   return process.env.GITHUB_ACTOR ?? "";
@@ -68,9 +69,9 @@ export function getGitHubActor(): string {
 /**
  * Returns the account ID of the person or app that triggered the workflow.
  *
- * This is the numeric ID, distinct from the username in `GITHUB_ACTOR`.
+ * This is distinct from the username in `GITHUB_ACTOR`.
  *
- * @returns The actor's account ID.
+ * @returns The actor's account ID, or an empty string if not set.
  */
 export function getGitHubActorId(): string {
   return process.env.GITHUB_ACTOR_ID ?? "";
@@ -79,14 +80,15 @@ export function getGitHubActorId(): string {
 /**
  * Returns the GitHub API URL.
  *
- * @returns The API URL, e.g. `https://api.github.com`.
+ * @returns The API URL (e.g. `https://api.github.com`), or an empty string
+ *   if not set.
  */
 export function getGitHubApiUrl(): string {
   return process.env.GITHUB_API_URL ?? "";
 }
 
 /**
- * Returns the target branch of a pull request.
+ * Returns the base branch of a pull request.
  *
  * Only set when the triggering event is `pull_request` or
  * `pull_request_target`.
@@ -101,7 +103,7 @@ export function getGitHubBaseRef(): string | undefined {
  * Returns the path to the file used to set environment variables from
  * workflow commands.
  *
- * @returns The path to the GitHub env file.
+ * @returns The path to the GitHub env file, or an empty string if not set.
  */
 export function getGitHubEnv(): string {
   return process.env.GITHUB_ENV ?? "";
@@ -110,7 +112,8 @@ export function getGitHubEnv(): string {
 /**
  * Returns the name of the event that triggered the workflow.
  *
- * @returns The event name, e.g. `push`, `pull_request`.
+ * @returns The event name (e.g. `push`, `pull_request`), or an empty string
+ *   if not set.
  */
 export function getGitHubEventName(): string {
   return process.env.GITHUB_EVENT_NAME ?? "";
@@ -119,7 +122,7 @@ export function getGitHubEventName(): string {
 /**
  * Returns the path to the file containing the full event webhook payload.
  *
- * @returns The path to the event payload file.
+ * @returns The path to the event payload file, or an empty string if not set.
  */
 export function getGitHubEventPath(): string {
   return process.env.GITHUB_EVENT_PATH ?? "";
@@ -128,7 +131,8 @@ export function getGitHubEventPath(): string {
 /**
  * Returns the GitHub GraphQL API URL.
  *
- * @returns The GraphQL API URL, e.g. `https://api.github.com/graphql`.
+ * @returns The GraphQL API URL (e.g. `https://api.github.com/graphql`), or
+ *   an empty string if not set.
  */
 export function getGitHubGraphqlUrl(): string {
   return process.env.GITHUB_GRAPHQL_URL ?? "";
@@ -149,7 +153,7 @@ export function getGitHubHeadRef(): string | undefined {
 /**
  * Returns the `job_id` of the current job as defined in the workflow file.
  *
- * @returns The current job ID.
+ * @returns The current job ID, or an empty string if not set.
  */
 export function getGitHubJob(): string {
   return process.env.GITHUB_JOB ?? "";
@@ -159,7 +163,7 @@ export function getGitHubJob(): string {
  * Returns the path to the file used to set step outputs from workflow
  * commands.
  *
- * @returns The path to the GitHub output file.
+ * @returns The path to the GitHub output file, or an empty string if not set.
  */
 export function getGitHubOutput(): string {
   return process.env.GITHUB_OUTPUT ?? "";
@@ -169,7 +173,7 @@ export function getGitHubOutput(): string {
  * Returns the path to the file used to prepend entries to the system `PATH`
  * from workflow commands.
  *
- * @returns The path to the GitHub path file.
+ * @returns The path to the GitHub path file, or an empty string if not set.
  */
 export function getGitHubPath(): string {
   return process.env.GITHUB_PATH ?? "";
@@ -178,7 +182,8 @@ export function getGitHubPath(): string {
 /**
  * Returns the fully-formed ref that triggered the workflow.
  *
- * @returns The full ref string, e.g. `refs/heads/main`, `refs/tags/v1.0`.
+ * @returns The full ref string (e.g. `refs/heads/main`, `refs/tags/v1.0`),
+ *   or an empty string if not set.
  */
 export function getGitHubRef(): string {
   return process.env.GITHUB_REF ?? "";
@@ -187,9 +192,9 @@ export function getGitHubRef(): string {
 /**
  * Returns the short ref name of the branch or tag that triggered the run.
  *
- * For unmerged pull requests the format is `<pr_number>/merge`.
+ * For `pull_request` events, the format is `<pr_number>/merge`.
  *
- * @returns The short ref name.
+ * @returns The short ref name, or an empty string if not set.
  */
 export function getGitHubRefName(): string {
   return process.env.GITHUB_REF_NAME ?? "";
@@ -208,7 +213,8 @@ export function getGitHubRefProtected(): boolean {
 /**
  * Returns the type of ref that triggered the workflow run.
  *
- * @returns The ref type, either `branch` or `tag`.
+ * @returns The ref type, either `branch` or `tag`, or an empty string if not
+ *   set.
  */
 export function getGitHubRefType(): string {
   return process.env.GITHUB_REF_TYPE ?? "";
@@ -217,18 +223,19 @@ export function getGitHubRefType(): string {
 /**
  * Returns the owner and repository name for the current repository.
  *
- * @returns The repository name in `owner/repo` format, e.g. `octocat/Hello-World`.
+ * @returns The repository name in `owner/repo` format
+ *   (e.g. `octocat/Hello-World`), or an empty string if not set.
  */
 export function getGitHubRepository(): string {
   return process.env.GITHUB_REPOSITORY ?? "";
 }
 
 /**
- * Returns the unique numeric ID of the repository.
+ * Returns the unique ID of the repository.
  *
  * This is distinct from the repository name.
  *
- * @returns The repository ID.
+ * @returns The repository ID, or an empty string if not set.
  */
 export function getGitHubRepositoryId(): string {
   return process.env.GITHUB_REPOSITORY_ID ?? "";
@@ -237,18 +244,18 @@ export function getGitHubRepositoryId(): string {
 /**
  * Returns the repository owner's username.
  *
- * @returns The repository owner's username.
+ * @returns The repository owner's username, or an empty string if not set.
  */
 export function getGitHubRepositoryOwner(): string {
   return process.env.GITHUB_REPOSITORY_OWNER ?? "";
 }
 
 /**
- * Returns the unique numeric account ID of the repository owner.
+ * Returns the unique account ID of the repository owner.
  *
  * This is distinct from the owner's username.
  *
- * @returns The repository owner's account ID.
+ * @returns The repository owner's account ID, or an empty string if not set.
  */
 export function getGitHubRepositoryOwnerId(): string {
   return process.env.GITHUB_REPOSITORY_OWNER_ID ?? "";
@@ -257,7 +264,7 @@ export function getGitHubRepositoryOwnerId(): string {
 /**
  * Returns the number of days that workflow run logs and artifacts are retained.
  *
- * @returns The retention period in days.
+ * @returns The retention period in days, or `0` if not set.
  */
 export function getGitHubRetentionDays(): number {
   return parseInt(process.env.GITHUB_RETENTION_DAYS ?? "0", 10);
@@ -268,7 +275,7 @@ export function getGitHubRetentionDays(): number {
  *
  * Starts at `1` for the first attempt and increments with each re-run.
  *
- * @returns The run attempt number.
+ * @returns The run attempt number, or `0` if not set.
  */
 export function getGitHubRunAttempt(): number {
   return parseInt(process.env.GITHUB_RUN_ATTEMPT ?? "0", 10);
@@ -279,7 +286,7 @@ export function getGitHubRunAttempt(): number {
  *
  * This value does not change if the workflow is re-run.
  *
- * @returns The workflow run ID.
+ * @returns The workflow run ID, or an empty string if not set.
  */
 export function getGitHubRunId(): string {
   return process.env.GITHUB_RUN_ID ?? "";
@@ -290,7 +297,7 @@ export function getGitHubRunId(): string {
  *
  * Starts at `1` for the first run and increments with each new run.
  *
- * @returns The workflow run number.
+ * @returns The workflow run number, or `0` if not set.
  */
 export function getGitHubRunNumber(): number {
   return parseInt(process.env.GITHUB_RUN_NUMBER ?? "0", 10);
@@ -299,7 +306,8 @@ export function getGitHubRunNumber(): number {
 /**
  * Returns the URL of the GitHub server.
  *
- * @returns The GitHub server URL, e.g. `https://github.com`.
+ * @returns The GitHub server URL (e.g. `https://github.com`), or an empty
+ *   string if not set.
  */
 export function getGitHubServerUrl(): string {
   return process.env.GITHUB_SERVER_URL ?? "";
@@ -310,7 +318,7 @@ export function getGitHubServerUrl(): string {
  *
  * The exact value depends on the triggering event.
  *
- * @returns The triggering commit SHA.
+ * @returns The triggering commit SHA, or an empty string if not set.
  */
 export function getGitHubSha(): string {
   return process.env.GITHUB_SHA ?? "";
@@ -320,7 +328,7 @@ export function getGitHubSha(): string {
  * Returns the path to the file used to persist state values from workflow
  * commands.
  *
- * @returns The path to the GitHub state file.
+ * @returns The path to the GitHub state file, or an empty string if not set.
  */
 export function getGitHubState(): string {
   return process.env.GITHUB_STATE ?? "";
@@ -330,7 +338,7 @@ export function getGitHubState(): string {
  * Returns the path to the file used to write job summaries from workflow
  * commands.
  *
- * @returns The path to the step summary file.
+ * @returns The path to the step summary file, or an empty string if not set.
  */
 export function getGitHubStepSummary(): string {
   return process.env.GITHUB_STEP_SUMMARY ?? "";
@@ -339,10 +347,10 @@ export function getGitHubStepSummary(): string {
 /**
  * Returns the username of the user who initiated the workflow run.
  *
- * May differ from `GITHUB_ACTOR` when the workflow is re-run by a different
- * user.
+ * May differ from {@link getGitHubActor} when the workflow is re-run by a
+ * different user.
  *
- * @returns The triggering actor's username.
+ * @returns The triggering actor's username, or an empty string if not set.
  */
 export function getGitHubTriggeringActor(): string {
   return process.env.GITHUB_TRIGGERING_ACTOR ?? "";
@@ -353,7 +361,7 @@ export function getGitHubTriggeringActor(): string {
  *
  * Defaults to the full file path if the workflow file has no `name` field.
  *
- * @returns The workflow name.
+ * @returns The workflow name, or an empty string if not set.
  */
 export function getGitHubWorkflow(): string {
   return process.env.GITHUB_WORKFLOW ?? "";
@@ -362,8 +370,9 @@ export function getGitHubWorkflow(): string {
 /**
  * Returns the ref path to the workflow file.
  *
- * @returns The workflow file ref path, e.g.
- *   `owner/repo/.github/workflows/ci.yml@refs/heads/main`.
+ * @returns The workflow file ref path
+ *   (e.g. `owner/repo/.github/workflows/ci.yml@refs/heads/main`), or an
+ *   empty string if not set.
  */
 export function getGitHubWorkflowRef(): string {
   return process.env.GITHUB_WORKFLOW_REF ?? "";
@@ -372,7 +381,7 @@ export function getGitHubWorkflowRef(): string {
 /**
  * Returns the commit SHA for the workflow file.
  *
- * @returns The workflow file's commit SHA.
+ * @returns The workflow file's commit SHA, or an empty string if not set.
  */
 export function getGitHubWorkflowSha(): string {
   return process.env.GITHUB_WORKFLOW_SHA ?? "";
@@ -382,7 +391,7 @@ export function getGitHubWorkflowSha(): string {
  * Returns the default working directory on the runner where the repository
  * is checked out.
  *
- * @returns The workspace path.
+ * @returns The workspace path, or an empty string if not set.
  */
 export function getGitHubWorkspace(): string {
   return process.env.GITHUB_WORKSPACE ?? "";
@@ -391,7 +400,8 @@ export function getGitHubWorkspace(): string {
 /**
  * Returns the CPU architecture of the runner executing the job.
  *
- * @returns The runner architecture, e.g. `X86`, `X64`, `ARM`, `ARM64`.
+ * @returns The runner architecture (e.g. `X86`, `X64`, `ARM`, `ARM64`), or
+ *   an empty string if not set.
  */
 export function getRunnerArch(): string {
   return process.env.RUNNER_ARCH ?? "";
@@ -411,7 +421,8 @@ export function getRunnerDebug(): boolean {
 /**
  * Returns the type of runner executing the job.
  *
- * @returns The runner environment type, either `github-hosted` or `self-hosted`.
+ * @returns The runner environment type, either `github-hosted` or
+ *   `self-hosted`, or an empty string if not set.
  */
 export function getRunnerEnvironment(): string {
   return process.env.RUNNER_ENVIRONMENT ?? "";
@@ -422,7 +433,7 @@ export function getRunnerEnvironment(): string {
  *
  * Names may not be unique across repository and organization levels.
  *
- * @returns The runner name.
+ * @returns The runner name, or an empty string if not set.
  */
 export function getRunnerName(): string {
   return process.env.RUNNER_NAME ?? "";
@@ -431,7 +442,8 @@ export function getRunnerName(): string {
 /**
  * Returns the operating system of the runner executing the job.
  *
- * @returns The runner OS, e.g. `Linux`, `Windows`, `macOS`.
+ * @returns The runner OS (e.g. `Linux`, `Windows`, `macOS`), or an empty
+ *   string if not set.
  */
 export function getRunnerOs(): string {
   return process.env.RUNNER_OS ?? "";
@@ -442,7 +454,7 @@ export function getRunnerOs(): string {
  *
  * This directory is cleared at the start and end of each job.
  *
- * @returns The runner temp directory path.
+ * @returns The runner temp directory path, or an empty string if not set.
  */
 export function getRunnerTemp(): string {
   return process.env.RUNNER_TEMP ?? "";
@@ -452,7 +464,7 @@ export function getRunnerTemp(): string {
  * Returns the path to the directory containing preinstalled tools for
  * GitHub-hosted runners.
  *
- * @returns The runner tool cache path.
+ * @returns The runner tool cache path, or an empty string if not set.
  */
 export function getRunnerToolCache(): string {
   return process.env.RUNNER_TOOL_CACHE ?? "";


### PR DESCRIPTION
## Summary

- Rewrote `README.md` with a module-first structure — module overview table, per-subpath sections with focused examples, scoped TypeDoc links (e.g. `interfaces/log.AnnotationOptions.html`), and a new `gha-utils/vars` section
- Updated `package.json` description to be more precise: "A utility library for building GitHub Actions with no runtime dependencies"
- Updated `CLAUDE.md` — added `pnpm typedoc --emit none` command, aligned command table columns, corrected `io.ts` and `log.ts` architecture descriptions, expanded `vars.ts` description to document context-specific `string | undefined` getters and absent-value defaults, and simplified the Testing section
- `src/exec.ts` — expanded stdout/stderr capture overload descriptions to mention the `"silent"` option and cross-reference the both-capture overload; added `@throws` to all overloads; fixed "behaviour" → "behavior"
- `src/io.ts` — added body paragraphs to all mutating functions explaining the underlying mechanism; added case-insensitivity note to `getInput`; added case-sensitivity note to `getState`; standardized "not found" → "not set" in `@returns`
- `src/log.ts` — expanded `AnnotationOptions` properties from single-line to multi-line JSDoc; added `col` naming note to explain the `col`/`endColumn` asymmetry; reordered fields to match serialization order; added cross-references between `beginLogGroup`/`endLogGroup` and `stopCommands`/`resumeCommands`; improved `@param options` descriptions for annotation functions
- `src/vars.ts` — standardized all `@returns` to include "or empty string / `0` if not set"; fixed "target branch" → "base branch" in `getGitHubBaseRef`; fixed "For unmerged pull requests" → "For `pull_request` events" in `getGitHubRefName`; removed "numeric" qualifier from ID field descriptions; added `{@link getGitHubActor}` cross-reference in `getGitHubTriggeringActor`

## Test plan

- [x] Verify `pnpm typedoc --emit none` passes (documentation build validates)
- [x] Verify `pnpm tsc` passes (no type errors introduced)
- [x] Verify `pnpm test` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)