### PR TITLE
Fix exports condition ordering in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,20 +17,20 @@
   "author": "Alfi Maulana <alfi.maulana.f@gmail.com>",
   "exports": {
     "./exec": {
-      "default": "./dist/exec.js",
-      "types": "./dist/exec.d.ts"
+      "types": "./dist/exec.d.ts",
+      "import": "./dist/exec.js"
     },
     "./io": {
-      "default": "./dist/io.js",
-      "types": "./dist/io.d.ts"
+      "types": "./dist/io.d.ts",
+      "import": "./dist/io.js"
     },
     "./log": {
-      "default": "./dist/log.js",
-      "types": "./dist/log.d.ts"
+      "types": "./dist/log.d.ts",
+      "import": "./dist/log.js"
     },
     "./vars": {
-      "default": "./dist/vars.js",
-      "types": "./dist/vars.d.ts"
+      "types": "./dist/vars.d.ts",
+      "import": "./dist/vars.js"
     }
   },
   "type": "module",


### PR DESCRIPTION
Reorder the `exports` conditions in `package.json` so that `"types"` comes before the module condition, and replace `"default"` with `"import"` to explicitly target ESM consumers.

This follows the [TypeScript recommendation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html) that the `"types"` condition must be listed first so TypeScript resolves it correctly under `node16`/`bundler` module resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)