### PR TITLE
Add engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "typescript-eslint": "^8.59.4",
     "vitest": "^4.0.15"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "packageManager": "pnpm@10.33.4"
 }


### PR DESCRIPTION
Add the `engines` field to enforce a minimum Node.js version of 24, matching the `@tsconfig/node24` baseline and the pinned version in `.npmrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)