### PR TITLE
Remove trim from getInput and getState

### DIFF
--- a/src/io.test.ts
+++ b/src/io.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
 
 describe("getInput", () => {
   test("retrieves a GitHub Actions input", () => {
-    process.env["INPUT_AN-INPUT"] = " a value  ";
+    process.env["INPUT_AN-INPUT"] = "a value";
     expect(getInput("an-input")).toBe("a value");
   });
 
@@ -55,7 +55,7 @@ describe("getInput", () => {
 
 describe("getState", () => {
   test("retrieves a GitHub Actions state", () => {
-    process.env["STATE_a-state"] = " a value  ";
+    process.env["STATE_a-state"] = "a value";
     expect(getState("a-state")).toBe("a value");
   });
 

--- a/src/io.ts
+++ b/src/io.ts
@@ -17,11 +17,10 @@ import {
  * `getInput("TOKEN")` both read the same `INPUT_TOKEN` env var.
  *
  * @param name - The name of the GitHub Actions input.
- * @returns The trimmed value of the GitHub Actions input, or an empty string if not set.
+ * @returns The value of the GitHub Actions input, or an empty string if not set.
  */
 export function getInput(name: string): string {
-  const value = process.env[`INPUT_${name.toUpperCase()}`] ?? "";
-  return value.trim();
+  return process.env[`INPUT_${name.toUpperCase()}`] ?? "";
 }
 
 /**
@@ -58,11 +57,10 @@ export function setOutputSync(name: string, value: string): void {
  * to {@link setState}.
  *
  * @param name - The name of the GitHub Actions state.
- * @returns The trimmed value of the GitHub Actions state, or an empty string if not set.
+ * @returns The value of the GitHub Actions state, or an empty string if not set.
  */
 export function getState(name: string): string {
-  const value = process.env[`STATE_${name}`] ?? "";
-  return value.trim();
+  return process.env[`STATE_${name}`] ?? "";
 }
 
 /**


### PR DESCRIPTION
Removes the implicit `.trim()` call from `getInput` and `getState` so the raw env var value is returned as-is.

Resolves #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)