### PR TITLE
Rename package to actkit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), set up with `
 
 ## Architecture
 
-`gha-utils` is a zero-runtime-dependency TypeScript library that wraps GitHub Actions' file-based APIs and workflow command syntax. It is published as four subpath exports, each corresponding to a source file.
+ActKit is a zero-runtime-dependency TypeScript toolkit that wraps GitHub Actions' file-based APIs and workflow command syntax. It is published as four subpath exports, each corresponding to a source file.
 
 **Source files and subpath exports** (in `src/`):
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
-# gha-utils
+# ActKit
 
-A TypeScript utility library for building [GitHub Actions](https://github.com/features/actions). Wraps GitHub Actions' file-based and stdout-based workflow APIs into typed, promise-friendly functions, with no runtime dependencies.
+A toolkit for building [GitHub Actions](https://github.com/features/actions). Wraps GitHub Actions' file-based and stdout-based workflow APIs into typed, promise-friendly functions, with no runtime dependencies.
 
 ## Installation
 
 ```sh
-npm install gha-utils
+npm install actkit
 ```
 
 ## Modules
 
-| Import                             | Purpose                                                             |
-| ---------------------------------- | ------------------------------------------------------------------- |
-| [`gha-utils/io`](#gha-utilsio)     | Read inputs; write outputs, state, env vars, and system paths       |
-| [`gha-utils/log`](#gha-utilslog)   | Log messages, mask secrets, group output, control workflow commands |
-| [`gha-utils/exec`](#gha-utilsexec) | Spawn child processes with stdout/stderr capture or suppression     |
-| [`gha-utils/vars`](#gha-utilsvars) | Typed getters for all default GitHub Actions variables              |
+| Import                        | Purpose                                                             |
+| ----------------------------- | ------------------------------------------------------------------- |
+| [`actkit/io`](#actkitio)      | Read inputs; write outputs, state, env vars, and system paths       |
+| [`actkit/log`](#actkitlog)    | Log messages, mask secrets, group output, control workflow commands |
+| [`actkit/exec`](#actkitexec)  | Spawn child processes with stdout/stderr capture or suppression     |
+| [`actkit/vars`](#actikitvars) | Typed getters for all default GitHub Actions variables              |
 
-Full API reference: [threeal.github.io/gha-utils](https://threeal.github.io/gha-utils)
+Full API reference: [threeal.github.io/actkit](https://threeal.github.io/actkit)
 
 ---
 
-## `gha-utils/io`
+## `actkit/io`
 
 ### Reading inputs
 
 ```ts
-import { getInput } from "gha-utils/io";
+import { getInput } from "actkit/io";
 
 const token = getInput("token"); // returns "" if the input is not set
 ```
@@ -34,19 +34,19 @@ const token = getInput("token"); // returns "" if the input is not set
 ### Writing outputs
 
 ```ts
-import { setOutput } from "gha-utils/io";
+import { setOutput } from "actkit/io";
 
 await setOutput("result", "success");
 ```
 
-A synchronous variant [`setOutputSync`](https://threeal.github.io/gha-utils/functions/io.setOutputSync.html) is also available.
+A synchronous variant [`setOutputSync`](https://threeal.github.io/actkit/functions/io.setOutputSync.html) is also available.
 
 ### State (pre/post steps)
 
 State persists across the pre, main, and post steps of the same action.
 
 ```ts
-import { getState, setState } from "gha-utils/io";
+import { getState, setState } from "actkit/io";
 
 // In the main step:
 await setState("cache-key", key);
@@ -55,46 +55,40 @@ await setState("cache-key", key);
 const cachedKey = getState("cache-key");
 ```
 
-A synchronous variant [`setStateSync`](https://threeal.github.io/gha-utils/functions/io.setStateSync.html) is also available.
+A synchronous variant [`setStateSync`](https://threeal.github.io/actkit/functions/io.setStateSync.html) is also available.
 
 ### Environment variables
 
 Sets the variable in the current process and exports it to subsequent steps.
 
 ```ts
-import { setEnv } from "gha-utils/io";
+import { setEnv } from "actkit/io";
 
 await setEnv("MY_VAR", "value");
 ```
 
-A synchronous variant [`setEnvSync`](https://threeal.github.io/gha-utils/functions/io.setEnvSync.html) is also available.
+A synchronous variant [`setEnvSync`](https://threeal.github.io/actkit/functions/io.setEnvSync.html) is also available.
 
 ### System path
 
 Prepends the path to `PATH` in the current process and exports it to subsequent steps.
 
 ```ts
-import { addPath } from "gha-utils/io";
+import { addPath } from "actkit/io";
 
 await addPath("/usr/local/custom/bin");
 ```
 
-A synchronous variant [`addPathSync`](https://threeal.github.io/gha-utils/functions/io.addPathSync.html) is also available.
+A synchronous variant [`addPathSync`](https://threeal.github.io/actkit/functions/io.addPathSync.html) is also available.
 
 ---
 
-## `gha-utils/log`
+## `actkit/log`
 
 ### Message levels
 
 ```ts
-import {
-  logDebug,
-  logError,
-  logInfo,
-  logNotice,
-  logWarning,
-} from "gha-utils/log";
+import { logDebug, logError, logInfo, logNotice, logWarning } from "actkit/log";
 
 logInfo("starting task");
 logDebug("verbose detail"); // only shown when debug logging is enabled
@@ -113,7 +107,7 @@ try {
 }
 ```
 
-`logNotice`, `logWarning`, and `logError` accept an optional [`AnnotationOptions`](https://threeal.github.io/gha-utils/interfaces/log.AnnotationOptions.html) to pin the message to a file location:
+`logNotice`, `logWarning`, and `logError` accept an optional [`AnnotationOptions`](https://threeal.github.io/actkit/interfaces/log.AnnotationOptions.html) to pin the message to a file location:
 
 ```ts
 logError("type mismatch", { file: "src/index.ts", line: 42, col: 5 });
@@ -130,7 +124,7 @@ logNotice("review this", { file: "src/index.ts", line: 1 });
 Outputs a `[command]` line to mark shell command execution in the workflow log.
 
 ```ts
-import { logCommand } from "gha-utils/log";
+import { logCommand } from "actkit/log";
 
 logCommand("git", "fetch", "--all"); // renders as [command]git fetch --all
 ```
@@ -140,7 +134,7 @@ logCommand("git", "fetch", "--all"); // renders as [command]git fetch --all
 Any subsequent occurrence of the masked value in the workflow logs is replaced with `***`.
 
 ```ts
-import { addLogMask } from "gha-utils/log";
+import { addLogMask } from "actkit/log";
 
 addLogMask(process.env.MY_SECRET ?? "");
 ```
@@ -150,7 +144,7 @@ addLogMask(process.env.MY_SECRET ?? "");
 All messages logged between `beginLogGroup` and `endLogGroup` are nested inside a collapsible section.
 
 ```ts
-import { beginLogGroup, endLogGroup, logInfo } from "gha-utils/log";
+import { beginLogGroup, endLogGroup, logInfo } from "actkit/log";
 
 beginLogGroup("build output");
 logInfo("compiling...");
@@ -163,7 +157,7 @@ Output between `stopCommands` and `resumeCommands` is not interpreted as workflo
 
 ```ts
 import { randomUUID } from "node:crypto";
-import { resumeCommands, stopCommands } from "gha-utils/log";
+import { resumeCommands, stopCommands } from "actkit/log";
 
 const token = randomUUID();
 stopCommands(token);
@@ -173,12 +167,12 @@ resumeCommands(token);
 
 ---
 
-## `gha-utils/exec`
+## `actkit/exec`
 
 Runs a command as a child process. By default, passes stdout and stderr to the current process. Rejects with an `Error` if the process fails to spawn, exits with a non-zero code, or is killed by a signal.
 
 ```ts
-import { exec } from "gha-utils/exec";
+import { exec } from "actkit/exec";
 
 await exec("git", ["fetch", "--all"]);
 ```
@@ -208,7 +202,7 @@ const { stdout, stderr } = await exec("git", ["rev-parse", "HEAD"], {
 
 ---
 
-## `gha-utils/vars`
+## `actkit/vars`
 
 Typed getters for every [default GitHub Actions variable](https://docs.github.com/en/actions/reference/workflows-and-actions/variables). Boolean variables return `boolean`, numeric count/day variables return `number`, context-specific variables (only set in certain events or action types) return `string | undefined`, and all others return `string`.
 
@@ -225,7 +219,7 @@ import {
   getRunnerArch,
   getRunnerDebug,
   getRunnerOs,
-} from "gha-utils/vars";
+} from "actkit/vars";
 
 const repo = getGitHubRepository(); // "owner/repo"
 const sha = getGitHubSha(); // triggering commit SHA
@@ -240,7 +234,7 @@ const arch = getRunnerArch(); // "X64", "ARM64", etc.
 const isDebug = getRunnerDebug(); // boolean
 ```
 
-For the full list of available getters, see the [API reference](https://threeal.github.io/gha-utils/modules/vars.html).
+For the full list of available getters, see the [API reference](https://threeal.github.io/actkit/modules/vars.html).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "gha-utils",
+  "name": "actkit",
   "version": "0.4.1",
-  "description": "A utility library for building GitHub Actions with no runtime dependencies",
+  "description": "A toolkit for building GitHub Actions with no runtime dependencies",
   "keywords": [
     "github",
     "actions",
-    "utility"
+    "toolkit"
   ],
-  "homepage": "https://threeal.github.io/gha-utils",
+  "homepage": "https://threeal.github.io/actkit",
   "bugs": {
-    "url": "https://github.com/threeal/gha-utils/issues",
+    "url": "https://github.com/threeal/actkit/issues",
     "email": "alfi.maulana.f@gmail.com"
   },
-  "repository": "github:threeal/gha-utils",
+  "repository": "github:threeal/actkit",
   "license": "MIT",
   "author": "Alfi Maulana <alfi.maulana.f@gmail.com>",
   "exports": {


### PR DESCRIPTION
Resolves #644.

Renames the package from `gha-utils` to `actkit` across all documentation and configuration files:

- `package.json`: name, description, keywords, homepage, bugs URL, repository
- `README.md`: title (`ActKit`), intro description, all module section headers, import examples, and API doc links
- `CLAUDE.md`: architecture description

🤖 Generated with [Claude Code](https://claude.com/claude-code)