### PR TITLE
Use `allowBuilds` in `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 packages:
   - .
-
-onlyBuiltDependencies:
-  - esbuild
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
It resolves #677 by replacing the deprecated `onlyBuiltDependencies` field with the new `allowBuilds` format in `pnpm-workspace.yaml`.

The `allowBuilds` field is the current pnpm configuration for controlling which packages are allowed to run lifecycle scripts during installation.