### PR TITLE
Utilize Setup Lefthook action in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
-      - name: Install Lefthook
-        run: |
-          curl -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.deb.sh' | sudo -E bash
-          sudo apt install lefthook
+      - name: Setup Lefthook
+        uses: threeal/setup-lefthook-action@v1.0.0
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v2.0.0


### PR DESCRIPTION
This pull request resolves #680 by replacing the manual Lefthook installation process in CI with the Setup Lefthook GitHub Action.
