### PR TITLE
Remove redundant `test` script from `package.json`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         run: lefthook run pre-commit --all-files
 
       - name: Test
-        run: pnpm test
+        run: pnpm vitest run
 
       - name: Package
         run: pnpm pack

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ pnpm tsc                 # type-check (no emit)
 pnpm eslint .            # lint
 pnpm prettier --write .  # format
 pnpm typedoc --emit none # validate documentation build
-pnpm test                # run tests with coverage
-pnpm test src/io.test.ts # run a single test file
+pnpm vitest run          # run all tests (Vitest)
+pnpm vitest run <file>   # run a single test file
 pnpm prepack             # compile to dist/
 ```
 

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "tsc -p tsconfig.build.json",
-    "test": "vitest run"
+    "prepack": "tsc -p tsconfig.build.json"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Removes the `test` script from `package.json`, which was just an alias for `vitest run`. The command is concise enough to invoke directly, so the alias adds no value.

## Changes

- Remove `scripts.test` from `package.json`
- Update CI workflow to call `pnpm vitest run` directly
- Update `CLAUDE.md` to reference `pnpm vitest run`

Closes #682